### PR TITLE
Here's the new commit message:

### DIFF
--- a/src/content/docs/pro/documenting/templates/automations/index.mdx
+++ b/src/content/docs/pro/documenting/templates/automations/index.mdx
@@ -32,6 +32,14 @@ Tallyfy automations use the same simple "if-this-then-that" idea:
 This lets you build processes that react automatically to different situations.
 :::
 
+:::tip[Automations: Like a "Choose Your Own Adventure" Story]
+Another way to think about automations is like a "choose your own adventure" story.
+
+- **Just like in those stories where your choices determine the plot, your process can branch out in different directions based on the information provided or actions taken.**
+- For example, if a customer selects 'Complaint' as a support ticket type (the 'choice'), the automation can route the ticket to a specialized team and trigger a high-priority notification (the 'adventure' path). If they select 'Feature Request', it might go to a product team backlog.
+- This allows one [template](/products/pro/documenting/templates/) to dynamically adapt to many different scenarios, guiding each [process](/products/pro/tracking-and-tasks/processes/) down the right path automatically.
+:::
+
 ### The main parts of an automation rule
 
 Every automation rule has two main parts:


### PR DESCRIPTION
Add 'choose your own adventure' analogy for automations

This commit introduces a new analogy to the Tallyfy automations documentation, comparing them to a "choose your own adventure" story.

The goal is to provide you with an additional, relatable way to understand how automations can create different paths and outcomes within a process based on defined conditions. This analogy is added as a :::tip block in the main automations article, complementing the existing thermostat analogy.

The new section adheres to the established tone, style, and formatting guidelines for Tallyfy documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an informational tip explaining automations using a "Choose Your Own Adventure" analogy, illustrating how automations can branch processes dynamically based on user input or actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->