### PR TITLE
Docs: Add crystal-clear definition of next_task behavior

### DIFF
--- a/src/content/docs/pro/integrations/open-api/code-samples/processes/get-process.mdx
+++ b/src/content/docs/pro/integrations/open-api/code-samples/processes/get-process.mdx
@@ -32,6 +32,40 @@ Replace `{org_id}` with your Organization ID and `{run_id}` with the specific ID
 -   `with` (string): A comma-separated list to include related data (e.g., `checklist`, `tasks`, `tags`, `assets`, `next_task`, `tasks.step`, `tasks.threads`, `form_fields`, `ko_form_fields`).
 -   `form_fields_values` (boolean, e.g., `true`): Include the values submitted to form fields.
 
+#### Understanding `with=next_task`
+
+When you include `next_task` in the `with` parameter, the API returns information about the next task that needs attention in the process.
+
+**What does `next_task` return?**
+- The first visible incomplete task ordered by position number
+- **Visible** means not hidden/auto-skipped by automation rules
+- **Incomplete** means not yet completed (includes tasks currently in-progress)
+- **Ordered by position** means task 1, task 2, task 3, etc.
+- Returns `null` if all tasks in the process are completed
+
+**When to use it:**
+- Determining which task to display to the user next
+- Automating assignments or notifications for upcoming tasks
+- Building custom dashboards that show current process status
+- Integration logic that needs to know what's pending
+
+**Example response snippet:**
+```json
+{
+  "data": {
+    "id": "run123",
+    "name": "Customer Onboarding",
+    "next_task": {
+      "id": "task456",
+      "title": "Review Application",
+      "position": 3,
+      "status": "not-started",
+      "deadline": "2025-10-25T17:00:00Z"
+    }
+  }
+}
+```
+
 ### Code samples
 
 <Tabs>

--- a/src/content/docs/pro/integrations/webhooks/how-can-i-use-tallyfys-webhooks-feature.mdx
+++ b/src/content/docs/pro/integrations/webhooks/how-can-i-use-tallyfys-webhooks-feature.mdx
@@ -72,7 +72,7 @@ The JSON payload sent by the webhook contains detailed information about the eve
 
 - **`this_task__*`**: Information about the specific task that triggered the webhook (e.g., `this_task__id`, `this_task__title`, `this_task__status`, `this_task__completed_by__email`, `this_task__completed_at`).
 - **`this_task__captures__*`**: Contains the values submitted to form fields within the completed task. The structure varies by field type (e.g., `this_task__captures__field_alias__value`).
-- **`next_task__*`**: Details about the task immediately following the completed task in the sequence (e.g., `next_task__id`, `next_task__title`, `next_task__owners__users`). This might be null if it was the last task.
+- **`next_task__*`**: Details about the next task that needs attention - specifically, the first visible incomplete task ordered by position number (e.g., `next_task__id`, `next_task__title`, `next_task__owners__users`). Visible means not auto-skipped. Incomplete includes in-progress tasks. Returns `null` if all tasks are completed.
 - **`process__*`**: Information about the overall process instance (e.g., `process__id`, `process__name`, `process__status`, `process__created_at__date`).
 - **`process__prerun__*`**: Contains values submitted in the kick-off form fields for the process.
 - **`process__process_forms__*`**: Contains values for *all* form fields across *all* tasks in the process up to that point.

--- a/src/content/docs/pro/integrations/webhooks/webhook-payload-structure.mdx
+++ b/src/content/docs/pro/integrations/webhooks/webhook-payload-structure.mdx
@@ -129,7 +129,9 @@ Process Webhook Payload
 
 ## Task-level webhook payload
 
-Task-level webhooks fire when a specific task completes. These contain detailed information about the completed task, all process data collected so far, and the next task in the sequence.
+Task-level webhooks fire when a specific task completes. These contain detailed information about the completed task, all process data collected so far, and the next task that needs attention.
+
+**What is `next_task`?** The first visible incomplete task ordered by position number. Visible means not auto-skipped by automation rules. Incomplete means not yet completed (includes tasks that are in-progress). Returns `null` if all tasks in the process are completed.
 
 ### Top-level structure
 


### PR DESCRIPTION
# Docs: Add crystal-clear definition of next_task behavior

## Summary

Updates documentation to provide state-of-the-art, crystal-clear explanation of what `next_task` means in Tallyfy's API and webhooks.

**Related:** API-v2 PR #8838 (fixed next_task bug)

## Problem

Current documentation was vague about what "next task" means:
- ❌ "the next task in the sequence" (too vague)
- ❌ "immediately following the completed task" (doesn't explain ordering)
- ❌ No explanation in API docs

Developers didn't understand:
- What "next" means (first by position? first not completed?)
- What "visible" means (auto-skipped tasks?)
- When it returns `null`

## Solution

Added precise, developer-friendly definitions across 3 key documentation files:

### 1. Webhook Payload Structure (`webhook-payload-structure.mdx`)

**Added:**
- Clear definition at section intro
- Explains ordering logic (by position number 1, 2, 3...)
- Defines "visible" (not auto-skipped)
- Defines "incomplete" (not completed, includes in-progress)
- States when `null` is returned

### 2. Webhook Feature Guide (`how-can-i-use-tallyfys-webhooks-feature.mdx`)

**Changed:**
- Before: "Details about the task immediately following the completed task in the sequence"
- After: "Details about the next task that needs attention - specifically, the first visible incomplete task ordered by position number"

### 3. API Documentation (`get-process.mdx`)

**Added entirely new section:**
- "Understanding `with=next_task`" subsection
- What it returns (4 clear bullet points)
- When to use it (4 practical use cases)
- Example JSON response

## Changes Made

### File 1: `webhook-payload-structure.mdx`
```markdown
**What is `next_task`?** The first visible incomplete task ordered by position number.
Visible means not auto-skipped by automation rules. Incomplete means not yet completed
(includes tasks that are in-progress). Returns `null` if all tasks in the process are completed.
```

### File 2: `how-can-i-use-tallyfys-webhooks-feature.mdx`
- Replaced vague "immediately following" description
- Added specific details about ordering, visibility, and null handling

### File 3: `get-process.mdx`
**Added complete subsection with:**
- Bullet point breakdown of behavior
- 4 practical use cases
- JSON response example

## Developer Benefits

After this update, developers will understand:
1. ✅ `next_task` returns first incomplete task by position
2. ✅ Auto-skipped tasks are excluded (automation rules)
3. ✅ In-progress tasks count as incomplete (still "next")
4. ✅ Returns `null` when process is fully completed
5. ✅ Ordering is by position number (not deadline, not created date)

## Testing

- [x] Reviewed all mentions of next_task in documentation
- [x] Consistent terminology across all 3 files
- [x] Aligned with actual API behavior (from PR #8838)
- [x] Added practical examples and use cases
- [x] Clear, concise, developer-friendly language

## Files Changed

```
src/content/docs/pro/integrations/webhooks/webhook-payload-structure.mdx
src/content/docs/pro/integrations/webhooks/how-can-i-use-tallyfys-webhooks-feature.mdx
src/content/docs/pro/integrations/open-api/code-samples/processes/get-process.mdx
```

## Related

- API-v2 PR #8838: Bug fix for next_task calculation
- HelpScout #3113933249: Original customer report
- API-v2 Issue #8837: next_task returns incorrect task

---

**Note:** This documentation aligns with the corrected API behavior after the bug fix in api-v2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies and standardizes the definition of `next_task` across API and webhook docs, adding a dedicated section with use cases and example in `get-process.mdx`.
> 
> - **Docs updates for `next_task`**
>   - **API (`src/content/docs/pro/integrations/open-api/code-samples/processes/get-process.mdx`)**:
>     - Adds "Understanding `with=next_task`" subsection with clear behavior bullets, practical use cases, and a JSON response snippet.
>   - **Webhooks guide (`webhooks/how-can-i-use-tallyfys-webhooks-feature.mdx`)**:
>     - Refines `next_task__*` description to define it as the first visible incomplete task ordered by position; notes null when all tasks complete.
>   - **Webhook payload reference (`webhooks/webhook-payload-structure.mdx`)**:
>     - Updates task-level intro to say "next task that needs attention" and adds an explicit definition block for `next_task` (visibility, incompleteness, ordering, null).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02097c12d746757dc6d9f70181d305138be349db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `next_task` field behavior in webhook payloads, specifying it represents the first visible incomplete task rather than simply the next sequential task.
  * Added explicit documentation that `next_task` returns null when all tasks are completed.
  * Enhanced webhook integration documentation with detailed explanations of field definitions and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->