### PR TITLE
docs(mcp): Session 8b refresh — tool count 113, Cloud Run mirror, OWASP hardening

### DIFF
--- a/src/content/docs/pro/integrations/mcp-server/claude-anthropic/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/claude-anthropic/index.mdx
@@ -13,7 +13,7 @@ title: Using Tallyfy MCP server with Claude (text chat)
 import { Steps, CardGrid, LinkTitleCard } from "~/components";
 
 :::note[Server endpoint]
-Tallyfy's MCP server is hosted at `https://mcp.tallyfy.com/` and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. The server speaks the standard streamable-http transport, authenticates via OAuth 2.1 with Dynamic Client Registration, and exposes the same tool surface to all Claude clients (Desktop, claude.ai connectors, Claude Code).
+Tallyfy's MCP server is hosted at `https://mcp.tallyfy.com/` (note the trailing slash, no `/mcp/` suffix) and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. The server speaks the standard streamable-http transport, authenticates via OAuth 2.1 with Dynamic Client Registration, and exposes the same 113 tools to all Claude clients (Desktop, claude.ai connectors, Claude Code). Access tokens carry the canonical `mcp_resource` claim so the server can bind the token to the resource it was issued for.
 :::
 
 ## Overview

--- a/src/content/docs/pro/integrations/mcp-server/google-gemini/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/google-gemini/index.mdx
@@ -13,11 +13,15 @@ title: Tallyfy MCP server with Google Gemini
 import { Steps, CardGrid, LinkTitleCard } from "~/components";
 import { Aside } from '@astrojs/starlight/components';
 
-:::note[Server endpoint]
-The MCP server is hosted at `https://mcp.tallyfy.com/` and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. Three Google surfaces connect to it: Gemini CLI, Gemini Code Assist, and Gemini Enterprise.
+:::note[Server endpoints]
+Tallyfy publishes two endpoints for Gemini: the primary at `https://mcp.tallyfy.com/` (DigitalOcean) and the **Google Cloud Run mirror at `https://mcp-gcp.tallyfy.com/`** (Tier-1 for Gemini Enterprise). Both expose the same 113 tools and share the same OAuth backend, so your access tokens work on either endpoint. The server is listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. Three Google surfaces connect to it: Gemini CLI, Gemini Code Assist, and Gemini Enterprise.
 :::
 
-Tallyfy connects to Google's three Gemini surfaces through OAuth 2.1 with streamable-HTTP transport. For developers, the Gemini CLI and Gemini Code Assist auto-discover OAuth via Dynamic Client Registration. For enterprise teams, admins add Tallyfy as a Custom MCP Server data store in the Gemini Enterprise console.
+Tallyfy connects to Google's three Gemini surfaces through OAuth 2.1 with streamable-HTTP transport. For developers, the Gemini CLI and Gemini Code Assist auto-discover OAuth via Dynamic Client Registration against `https://mcp.tallyfy.com/`. For enterprise teams, admins add Tallyfy as a Custom MCP Server data store in the Gemini Enterprise console; we recommend using `https://mcp-gcp.tallyfy.com/` (the Cloud Run mirror) for that path since it puts the origin inside Google's own network.
+
+:::tip[Why two endpoints?]
+The Cloud Run mirror (`mcp-gcp.tallyfy.com`) is operationally identical to the primary endpoint but is hosted on Google Cloud Run. For Gemini Enterprise customers this means lower-latency egress, easier VPC-SC and Cloud Logging integration, and an origin that lives inside Google's compliance perimeter. The deploy pipeline (Cloud Build → Artifact Registry → Cloud Run) is fully operational; every push to the MCP server repo deploys to both endpoints in parallel. Pick whichever endpoint your AI surface prefers; the data and behavior are the same.
+:::
 
 ## Gemini MCP support status
 
@@ -118,10 +122,10 @@ Gemini Enterprise's Custom MCP Server data store (Preview as of May 2026) is con
 
 3. **Register an OAuth client for Tallyfy**
 
-   Tallyfy supports Dynamic Client Registration. Register a confidential client for Gemini Enterprise with one curl call:
+   Tallyfy supports Dynamic Client Registration. Register a confidential client for Gemini Enterprise with one curl call. The server advertises both `client_secret_basic` and `client_secret_post` as supported token endpoint auth methods - Gemini Enterprise typically uses `client_secret_basic`, but either works:
 
    ```bash
-   curl -s -X POST https://mcp.tallyfy.com/mcp/oauth/register \
+   curl -s -X POST https://mcp-gcp.tallyfy.com/mcp/oauth/register \
      -H "Content-Type: application/json" \
      -d '{
        "client_name": "Gemini Enterprise - YourOrgName",
@@ -132,20 +136,23 @@ Gemini Enterprise's Custom MCP Server data store (Preview as of May 2026) is con
      }'
    ```
 
-   The response contains both `client_id` and `client_secret`. Save both — you'll paste them into the Cloud Console in the next step.
+   The response contains both `client_id` and `client_secret`. Save both - you'll paste them into the Cloud Console in the next step. You can register against either endpoint (`mcp.tallyfy.com` or `mcp-gcp.tallyfy.com`); the credentials are valid on both because they share the OAuth backend.
 
 4. **Add the data store in Cloud Console**
 
-   In Google Cloud Console: **Gemini Enterprise** -> **Data stores** -> **Create data store** -> **Custom MCP Server (Preview)** -> **Add MCP server**. Fill the form:
+   In Google Cloud Console: **Gemini Enterprise** -> **Data stores** -> **Create data store** -> **Custom MCP Server (Preview)** -> **Add MCP server**. Fill the form using the **Cloud Run mirror** so your origin stays inside Google's network:
 
    | Field | Value |
    |---|---|
-   | **MCP Server URL** | `https://mcp.tallyfy.com/` |
-   | **Authorization URL** | `https://mcp.tallyfy.com/mcp/oauth/authorize` |
-   | **Token URL** | `https://mcp.tallyfy.com/mcp/oauth/token` |
+   | **MCP Server URL** | `https://mcp-gcp.tallyfy.com/` |
+   | **Authorization URL** | `https://mcp-gcp.tallyfy.com/mcp/oauth/authorize` |
+   | **Token URL** | `https://mcp-gcp.tallyfy.com/mcp/oauth/token` |
    | **Client ID** | (from step 3 response) |
    | **Client Secret** | (from step 3 response) |
+   | **Token endpoint auth method** | `client_secret_basic` (or `client_secret_post`) |
    | **Scopes** | `mcp.users.read mcp.tasks.read mcp.tasks.write mcp.processes.read mcp.processes.write mcp.templates.read mcp.templates.write mcp.forms.read mcp.forms.write mcp.automation.read mcp.automation.write` |
+
+   If you prefer the DigitalOcean origin, swap all three URLs to `mcp.tallyfy.com` - the behavior is identical.
 
 5. **Add a server description**
 
@@ -227,7 +234,7 @@ Build multi-agent systems with the Agent Development Kit that combine Tallyfy wi
 - **Tools default to disabled** - after creating the data store, you must manually enable each Tallyfy tool via **Actions** -> **Reload custom actions**.
 - **No public Google directory for MCP server vendors** - Tallyfy isn't surfaced by default to Gemini Enterprise customers. Each org adds it themselves through the steps above.
 - **Visual process tracker doesn't render in chat** - like other chat surfaces, Gemini shows you text. Complex forms become text interactions, and you'll ask for status updates explicitly.
-- **OAuth client types supported** - Tallyfy supports both PKCE public clients (CLI, Code Assist) and confidential clients with `client_secret_basic` (Gemini Enterprise). All flows use OAuth 2.1 with S256 PKCE.
+- **OAuth client types supported** - Tallyfy supports both PKCE public clients (CLI, Code Assist) and confidential clients (Gemini Enterprise). Confidential clients can use either `client_secret_basic` or `client_secret_post` for the token endpoint; both methods are advertised in the server's `/.well-known/oauth-authorization-server` metadata. All flows use OAuth 2.1 with S256 PKCE.
 
 ## Best use cases
 
@@ -254,7 +261,7 @@ Monitor active processes and alert me to any at risk of missing their SLA, with 
 
 ## Security
 
-- **Authentication** - OAuth 2.1. Gemini CLI and Code Assist register as PKCE public clients through DCR. Gemini Enterprise registers as a confidential client (`client_secret_basic`) through DCR. All flows use S256 PKCE for code challenge. Refresh tokens rotate automatically.
+- **Authentication** - OAuth 2.1. Gemini CLI and Code Assist register as PKCE public clients through DCR. Gemini Enterprise registers as a confidential client through DCR using `client_secret_basic` or `client_secret_post` (both advertised by the server). All flows use S256 PKCE for code challenge. Refresh tokens rotate automatically.
 - **Data handling** - Google processes your data per their AI policies. Enterprise teams get Vertex AI controls and audit logging in Cloud Logging.
 - **Network** - All traffic over HTTPS. Enterprise deployments can add VPC Service Controls and private connectivity.
 

--- a/src/content/docs/pro/integrations/mcp-server/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/index.mdx
@@ -12,8 +12,8 @@ title: MCP server
 
 ## Tallyfy MCP server
 
-:::note[Listed on the Official MCP Registry]
-Tallyfy's MCP server is published on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server` (DNS-verified, version 1.0.0). The endpoint is `https://mcp.tallyfy.com/` and connects with **OpenAI ChatGPT**, **Anthropic Claude** (Desktop, claude.ai, Claude Code), **Google Gemini**, **Microsoft Copilot Studio**, **Cursor**, **Cline**, **Continue**, and any other MCP-compatible AI client.
+:::note[Listed on public MCP directories]
+Tallyfy's MCP server is published on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server` (DNS-verified, version 1.0.0) and on [Smithery](https://smithery.ai/). The primary endpoint is `https://mcp.tallyfy.com/` (DigitalOcean) with a Google Cloud Run mirror at `https://mcp-gcp.tallyfy.com/` for Gemini Enterprise customers. Both endpoints expose the same 113 tools and connect with **OpenAI ChatGPT**, **Anthropic Claude** (Desktop, claude.ai, Claude Code), **Google Gemini**, **Microsoft Copilot Studio**, **Cursor**, **Cline**, **Continue**, and any other MCP-compatible AI client.
 :::
 
 :::note[MCP client compatibility]
@@ -28,7 +28,7 @@ MCP is a universal translator between AI assistants and your business tools. It'
 
 ### How it works
 
-The MCP Server connects AI assistants (Claude, ChatGPT, Gemini, Copilot, and others) directly to your Tallyfy organization. Connect with OAuth 2.1 authentication or an API token, and you can:
+The MCP Server exposes 113 tools that connect AI assistants (Claude, ChatGPT, Gemini, Copilot, and others) directly to your Tallyfy organization. Connect with OAuth 2.1 authentication or an API token, and you can:
 
 - Ask questions about your [processes](/products/pro/tracking-and-tasks/processes/) and [tasks](/products/pro/tracking-and-tasks/tasks/) in plain English
 - Create, complete, and manage tasks through conversation
@@ -125,6 +125,12 @@ Coming soon:
 - Connections to other [middleware](/products/pro/integrations/middleware/) platforms
 - Real-time team collaboration features
 
+### Recent updates
+
+- **OWASP MCP Top-10 audit closed (May 2026)** - the server passed a full OWASP MCP-specific threat model with hardening for prompt injection, indirect tool calls, scope confusion, and token leakage paths
+- **Cloud Run mirror operational (May 2026)** - `https://mcp-gcp.tallyfy.com/` brought up as the Tier-1 origin for Gemini Enterprise customers; the Google Cloud build pipeline is now unblocked and deploys on every push
+- **Cross-process structured logging** - the MCP host's request/response audit trail now flows into Tallyfy's central logging backend, joining the same observability stack as API and email events
+
 ### Technical architecture
 
 The MCP server is built from:
@@ -136,12 +142,16 @@ The MCP server is built from:
 
 Public endpoints:
 
-- `https://mcp.tallyfy.com/` - the streamable-http MCP endpoint
+- `https://mcp.tallyfy.com/` - the primary streamable-http MCP endpoint (DigitalOcean)
+- `https://mcp-gcp.tallyfy.com/` - the Google Cloud Run mirror (Tier-1 path for Gemini Enterprise)
 - `https://mcp.tallyfy.com/.well-known/oauth-protected-resource` - OAuth resource metadata
 - `https://mcp.tallyfy.com/.well-known/oauth-authorization-server` - OAuth authorization server metadata
 - `https://mcp.tallyfy.com/.well-known/jwks.json` - public RS256 signing key
+- `https://mcp.tallyfy.com/.well-known/openai-apps-challenge` - OpenAI Apps directory verification challenge
 - `https://mcp.tallyfy.com/health` - health check
 - `https://mcp.tallyfy.com/privacy` - MCP-specific privacy summary
+
+Both endpoints share the same OAuth backend, the same 113 tools, and the same Tallyfy organization data. Pick `mcp.tallyfy.com` by default; use `mcp-gcp.tallyfy.com` when your AI platform (Gemini Enterprise in particular) prefers a Google Cloud-hosted origin.
 
 ## Limitations of text-based AI interfaces
 

--- a/src/content/docs/pro/integrations/mcp-server/microsoft-copilot-studio/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/microsoft-copilot-studio/index.mdx
@@ -13,11 +13,11 @@ title: Using Tallyfy MCP server with Microsoft Copilot Studio
 import { Steps, CardGrid, LinkTitleCard } from "~/components";
 
 :::note[Server endpoint]
-The MCP server is hosted at `https://mcp.tallyfy.com/` and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. Copilot Studio connects via streamable HTTP with OAuth 2.1.
+The MCP server is hosted at `https://mcp.tallyfy.com/` and exposes 113 tools. It's listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. Copilot Studio connects via streamable HTTP with OAuth 2.1.
 :::
 
 :::tip[Already a Microsoft Verified Publisher]
-Tallyfy is a Microsoft Verified Publisher with a [Power Automate connector](https://learn.microsoft.com/en-us/connectors/tallyfy/) that's been live for years. The MCP path is the natural next step for AI-driven workflow ops on the Microsoft stack.
+Tallyfy is a Microsoft Verified Publisher with a [Power Automate connector](https://learn.microsoft.com/en-us/connectors/tallyfy/) that's been live for years. The MCP path is the natural next step for AI-driven workflow ops on the Microsoft stack. Direct MCP support inside Copilot Studio (skipping the custom-connector wrapper) is under active investigation with Microsoft.
 :::
 
 ## Overview

--- a/src/content/docs/pro/integrations/mcp-server/openai-chatgpt/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/openai-chatgpt/index.mdx
@@ -13,7 +13,7 @@ title: Using Tallyfy MCP server with ChatGPT
 import { Steps, CardGrid, LinkTitleCard } from "~/components";
 
 :::note[Server endpoint]
-The MCP server is hosted at `https://mcp.tallyfy.com/`. ChatGPT supports it through Custom Connectors (Team, Enterprise, Education plans) and through ChatGPT Apps (when you've installed it from the apps directory). The server is also published on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`.
+The MCP server is hosted at `https://mcp.tallyfy.com/` and exposes 113 tools. ChatGPT supports it through Custom Connectors (Team, Enterprise, Education plans) and through ChatGPT Apps (when you've installed it from the apps directory). The server is also published on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`. A verification endpoint at `https://mcp.tallyfy.com/.well-known/openai-apps-challenge` confirms ownership for OpenAI's Apps directory; Tallyfy's directory listing is in progress with OpenAI.
 :::
 
 ## What this integration does
@@ -254,6 +254,7 @@ ChatGPT analyzes your data and returns the answer with links to the specific [pr
 - **Write capabilities** - Already available via Developer Mode
 - **OAuth 2.1** - Live now with PKCE and Dynamic Client Registration
 - **Apps SDK** - Build custom UIs alongside MCP servers
+- **OpenAI Apps directory listing** - Tallyfy's submission is in progress; the verification challenge endpoint at `/.well-known/openai-apps-challenge` is already live
 - **Real-time sync** - Live updates between ChatGPT and Tallyfy (coming soon)
 
 OpenAI and Tallyfy are both expanding MCP features. MCP is governed by the Agentic AI Foundation under the Linux Foundation.

--- a/src/content/docs/pro/integrations/mcp-server/sso-authentication/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/sso-authentication/index.mdx
@@ -22,6 +22,8 @@ SSO integration with MCP servers solves **repeated authentication across multipl
 
 Tallyfy's MCP server already implements OAuth 2.1 with PKCE S256, Dynamic Client Registration (RFC 7591), and authorization server metadata discovery (RFC 8414). Tokens are RS256-signed JWTs with the public key at `/.well-known/jwks.json`. The well-known endpoint at `/.well-known/oauth-authorization-server` lets AI clients like ChatGPT and Claude Desktop discover OAuth endpoints automatically. Scopes use dot notation, for example `mcp.tasks.read`, `mcp.processes.write`, and `mcp.templates.read`. The server is listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=tallyfy) as `com.tallyfy/mcp-server`.
 
+**Token resource binding (`mcp_resource` claim)** - Access tokens carry a canonical `mcp_resource` claim that pins the token to a specific MCP resource URL (the server endpoint it was issued for). The server uses this claim to detect and reject tokens replayed against a different resource. For backwards compatibility with legacy Passport-issued tokens (which use `aud: 1`), the server also accepts tokens that lack `mcp_resource` but present the expected legacy audience, so existing integrations keep working while new clients get the stricter binding.
+
 ## The authentication challenge in MCP
 
 MCP servers don't know who you are by default. They receive requests from AI agents with no identity or context. This creates gaps when accessing enterprise systems that need user credentials.


### PR DESCRIPTION
## Summary

Refreshes the 6 existing MCP integration pages on `tallyfy/documentation` with post-Session-8b state. Targeted edits only — no new pages, no Related-articles tampering, no frontmatter changes that the pipeline owns.

### What's updated, per page

- **`mcp-server/index.mdx`** (landing) — Tool count 110→113; Smithery + Official Registry both listed; Cloud Run mirror endpoint added; OpenAI Apps challenge endpoint listed; new "Recent updates" section (OWASP audit closed, Cloud Run mirror operational, cross-process structured logging).
- **`mcp-server/claude-anthropic/index.mdx`** — Endpoint callout clarifies `https://mcp.tallyfy.com/` (no `/mcp/` suffix), 113-tool count, and the canonical `mcp_resource` token claim (PR #402).
- **`mcp-server/openai-chatgpt/index.mdx`** — Endpoint callout mentions 113 tools and the `/.well-known/openai-apps-challenge` verification endpoint (PR #464); "What's next" lists the in-progress Apps directory submission.
- **`mcp-server/microsoft-copilot-studio/index.mdx`** — Endpoint callout mentions 113 tools; Verified Publisher tip extended with the MCP-direct support investigation note (#426).
- **`mcp-server/google-gemini/index.mdx`** — Biggest change. Server-endpoints callout now lists both `mcp.tallyfy.com` and `mcp-gcp.tallyfy.com` (Tier-1 for Gemini Enterprise). New "Why two endpoints?" tip explains Cloud Run path. Gemini Enterprise data store steps now recommend the Cloud Run mirror, with `client_secret_basic` AND `client_secret_post` both advertised (PR #473). OAuth client types limitation + Security section updated to reflect both auth methods.
- **`mcp-server/sso-authentication/index.mdx`** — New paragraph on token resource binding: canonical `mcp_resource` claim semantics (PR #402) plus backwards compatibility for legacy `aud: 1` Passport tokens (PR #403).

### What's intentionally NOT changed

- **No new `claude-desktop-setup/` page** — Phase 10 (S-7 manual Claude Desktop interview) hasn't happened yet, so we have no screenshots and no walkthrough to embed. Will be added in a later session.
- `lastUpdated`, `id`, and `Related articles` left alone — the documentation pipeline regenerates these on staging.

### Validation run

- `python3 scripts/markdown-lint.py --dir src/content/docs/pro/integrations/mcp-server` — passes (exit 0)
- `python3 scripts/validate-internal-links.py --dir src/content/docs/pro/integrations/mcp-server` — passes (37 links checked, 0 broken)
- Zero em-dashes in the new content (per repo CLAUDE.md humanization rules)
- Zero blacklisted words introduced

## Test plan

- [ ] Reviewer skims each of the 6 page diffs and confirms tone/style matches surrounding content
- [ ] After merge to staging, check that `staging.tallyfy.com/products/pro/integrations/mcp-server/` and the 5 sub-pages render correctly
- [ ] Confirm pipeline-regenerated `lastUpdated` reflects the merge date and the `Related articles` section regenerates cleanly
- [ ] Spot-check the Cloud Run mirror URL (`mcp-gcp.tallyfy.com`) renders as code in the rendered HTML, not as a clickable link with an empty href

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change no runtime behavior; risk is limited to potential user confusion if endpoint/auth details are incorrect.
> 
> **Overview**
> Updates the MCP server docs to reflect the current integration surface: **113 tools**, clarified endpoint formatting, and expanded endpoint metadata (adds the `mcp-gcp.tallyfy.com` Cloud Run mirror for Gemini Enterprise and references the `/.well-known/openai-apps-challenge` verification URL).
> 
> Refreshes provider-specific setup guidance: Gemini Enterprise setup now recommends the Cloud Run mirror and documents both `client_secret_basic` and `client_secret_post`; Claude and SSO pages note the `mcp_resource` token-binding claim; Copilot Studio and ChatGPT pages call out the 113-tool surface and related status notes. Adds a **Recent updates** section to the MCP landing page covering OWASP hardening, mirror availability, and structured logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079b398c69dc5b73ede7de90310e92f4f0d4bff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced MCP server integration guides with expanded endpoint details and URL requirements for Claude, Gemini, Copilot Studio, and OpenAI integrations.
  * Added new Google Cloud Run mirror endpoint option for Gemini Enterprise.
  * Clarified OAuth authentication methods and token behavior across endpoints.
  * Added endpoint specifications, tool count information, and registry listings to integration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tallyfy/documentation/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->