### PR TITLE
feat: add Tallyfy Desktop AI integration section (closes tallyfy/desktop#38)

### DIFF
--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-claude.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-claude.mdx
@@ -2,7 +2,7 @@
 about_tallyfy: true
 description: Install the Anthropic Claude CLI and sign into your Claude.ai subscription so Tallyfy Desktop can drive it. The Install Wizard handles the bash installer with explicit consent, or you can install manually from anthropic.com.
 sidebar:
-  order: 10
+  order: 2
   label: Connect Claude
 title: Connect Claude to Tallyfy Desktop
 ---
@@ -10,7 +10,7 @@ title: Connect Claude to Tallyfy Desktop
 import { Steps, CardGrid, LinkTitleCard } from "~/components";
 
 :::note[Subscription, not API key]
-Claude in Tallyfy Desktop uses OAuth via your Claude.ai account (Pro, Max, Team, or Enterprise plan). The app never asks for an `ANTHROPIC_API_KEY` and won't accept one. If you don't have a Claude subscription, sign up at [claude.ai](https://claude.ai) first.
+Claude in Tallyfy Desktop uses OAuth via your Claude.ai account (Pro, Max, Team, or Enterprise plan). The app never asks for an `ANTHROPIC_API_KEY` and won't accept one. If you don't have a Claude subscription, sign up at [claude.ai](https://claude.ai)<a href="https://claude.ai" rel="nofollow noopener noreferrer" target="_blank"><sup>[1]</sup></a> first.
 :::
 
 ## What gets installed
@@ -172,7 +172,7 @@ Claude is the most capable provider in Tallyfy Desktop v2.0.0:
 - **Tool use** - Claude can call MCP tools (Tallyfy's auto-injected MCP server) during the chat, not just at the end. You'll see `tool-use-start` and `tool-use-end` events stream in the chat.
 - **Thinking** - Claude streams its reasoning in a separate channel that's visible in the chat (collapsible).
 - **Cost reporting** - Claude reports the exact USD cost of each run on completion.
-- **Browser automation** - the `claude --chrome` flag drives a sandboxed Chrome instance for browser-bound workflows. See the [desktop repo's COMPUTER-USE-DEFERRED doc](https://github.com/tallyfy/desktop/blob/main/docs/COMPUTER-USE-DEFERRED.md) for what it can and can't do.
+- **Browser automation** - the `claude --chrome` flag drives a sandboxed Chrome instance for browser-bound workflows. See the [desktop repo's COMPUTER-USE-DEFERRED doc](https://github.com/tallyfy/desktop/blob/main/docs/COMPUTER-USE-DEFERRED.md)<a href="https://github.com/tallyfy/desktop/blob/main/docs/COMPUTER-USE-DEFERRED.md" rel="nofollow noopener noreferrer" target="_blank"><sup>[2]</sup></a> for what it can and can't do.
 - **Attachments** - drag a file into the chat and Claude reads it (limited to text and images in v1).
 
 The other providers cover subsets of these. See the [overview](/products/pro/integrations/tallyfy-desktop-ai/) for the full capability matrix.

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-claude.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-claude.mdx
@@ -1,0 +1,186 @@
+---
+about_tallyfy: true
+description: Install the Anthropic Claude CLI and sign into your Claude.ai subscription so Tallyfy Desktop can drive it. The Install Wizard handles the bash installer with explicit consent, or you can install manually from anthropic.com.
+sidebar:
+  order: 10
+  label: Connect Claude
+title: Connect Claude to Tallyfy Desktop
+---
+
+import { Steps, CardGrid, LinkTitleCard } from "~/components";
+
+:::note[Subscription, not API key]
+Claude in Tallyfy Desktop uses OAuth via your Claude.ai account (Pro, Max, Team, or Enterprise plan). The app never asks for an `ANTHROPIC_API_KEY` and won't accept one. If you don't have a Claude subscription, sign up at [claude.ai](https://claude.ai) first.
+:::
+
+## What gets installed
+
+Tallyfy Desktop drives Claude through Anthropic's official `claude` command-line tool (Claude Code). On first launch, the desktop app checks whether `claude` is on your `PATH` and whether you've signed in. If either is missing, it offers to install or guide you.
+
+The install command per platform is baked into the desktop app source code:
+
+| Platform | Command |
+|---|---|
+| macOS | `curl -fsSL https://claude.ai/install.sh \| bash` |
+| Linux | `curl -fsSL https://claude.ai/install.sh \| bash` |
+| Windows | `powershell -Command "irm https://claude.ai/install.ps1 \| iex"` |
+
+Binaries land under `~/.local/bin/` on macOS and Linux, and under `%LOCALAPPDATA%\claude\bin\` on Windows. No `sudo` or admin rights are required.
+
+## Prerequisites
+
+- A Tallyfy account (you'll sign in to Tallyfy Desktop first, before any AI tab works)
+- A Claude.ai subscription on Pro, Max, Team, or Enterprise plan
+- A modern web browser for the OAuth sign-in step (the desktop app opens it for you)
+
+## Option A: Install Wizard (recommended)
+
+This is the path the desktop app guides you through. The wizard shows the exact command before it runs and asks for an explicit consent gesture.
+
+<Steps>
+
+1. **Open the Claude tab**
+
+   In Tallyfy Desktop, click the **Claude** tab. If the CLI isn't installed, the Install Wizard appears.
+
+2. **Read the consent screen**
+
+   The wizard shows:
+   - The provider being installed (Claude, Anthropic)
+   - The exact command that will run (the `curl ... | bash` line for your platform)
+   - A risks list (network egress, disk writes under `~/.local/bin/`, no system modification)
+   - A "Hold Shift to install" button
+
+   ![Install Wizard with the consent screen for Claude](https://screenshots.tallyfy.com/desktop-ai/install-wizard-consent.png)
+
+3. **Hold Shift for three seconds**
+
+   The button activates only while you hold the Shift key for three seconds. This intentional friction prevents accidental installs. Release the key to cancel.
+
+4. **Watch the progress log**
+
+   The wizard streams the installer's output in real time. You'll see download progress, the binary unpacking, and a final "Installed Claude vX.Y.Z" line.
+
+   ![Install Wizard with the progress log showing a successful Claude install](https://screenshots.tallyfy.com/desktop-ai/install-wizard-progress.png)
+
+5. **Verify**
+
+   The wizard runs `claude --version` and shows the result. If you see a version number, the binary works.
+
+6. **Sign in with Claude.ai**
+
+   Click **Sign in with Claude**. The desktop app opens Claude's OAuth flow in your default browser. Approve the connection. The browser will redirect back to a confirmation page; close it when prompted.
+
+   The token is stored under `~/.claude/.credentials.json` (and in macOS Keychain on Darwin systems). The desktop app reads it from there; you don't paste it anywhere.
+
+7. **Test the connection**
+
+   Back in the Claude tab, type `hi` and press Enter. You should see Claude's streamed response within a few seconds, with the model name in the header.
+
+</Steps>
+
+## Option B: Manual install
+
+If you'd rather install Claude outside the desktop app, that works too. Tallyfy Desktop only checks whether `claude` is on `PATH`; it doesn't care how it got there.
+
+<Steps>
+
+1. **Install the Claude CLI**
+
+   Open a terminal and run:
+
+   - **macOS / Linux**: `curl -fsSL https://claude.ai/install.sh | bash`
+   - **Windows (PowerShell)**: `irm https://claude.ai/install.ps1 | iex`
+
+2. **Sign in**
+
+   In the same terminal: `claude login`
+
+   This opens Claude's OAuth flow in your browser. Approve and return to the terminal.
+
+3. **Restart Tallyfy Desktop**
+
+   Quit the app fully (Cmd+Q on macOS, File then Quit on Windows/Linux) and reopen it. The Claude tab will detect the new binary and skip the Install Wizard.
+
+</Steps>
+
+## First chat
+
+Once Claude is connected:
+
+1. Click the **Claude** tab.
+2. The model picker in the top-right shows the default Claude model (Sonnet 4.6 in v2.0.0).
+3. Type your message and press Enter. You'll see the streamed response appear chunk by chunk.
+4. The chat header shows the cost and token usage on completion.
+
+Because the [Tallyfy MCP server](/products/pro/integrations/mcp-server/) is auto-injected, Claude already knows about your tasks, processes, templates, and team. Try:
+
+- "Show me all my open tasks"
+- "Find the customer onboarding template"
+- "Create a task to review next quarter's hiring plan, due Friday"
+
+That last one will trigger the [Task Intent Widget](/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/), which offers a one-click button to create the task in Tallyfy.
+
+## Verifying the install yourself
+
+If something feels off, you can check the same things the desktop app checks:
+
+```bash
+# Is the binary on PATH?
+which claude
+
+# Does it run?
+claude --version
+
+# Are you signed in?
+test -f ~/.claude/.credentials.json && echo "signed in" || echo "not signed in"
+```
+
+The desktop app caches the detection result for 60 minutes. Press **Cmd+Shift+R** (or **Ctrl+Shift+R** on Windows/Linux) inside the Claude tab to force a re-detection after an install or login.
+
+## Troubleshooting
+
+### "`claude` binary not found" after install
+
+The installer writes to `~/.local/bin/` (or `%LOCALAPPDATA%\claude\bin\` on Windows), which isn't always on the default `PATH`. Add it:
+
+- **macOS / Linux**: `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc` (or `~/.bashrc`), then restart Tallyfy Desktop.
+- **Windows**: open System Properties, click Environment Variables, add `%LOCALAPPDATA%\claude\bin` to your user `Path`.
+
+Then press Cmd+Shift+R (Ctrl+Shift+R on Windows/Linux) inside the Claude tab to retry detection.
+
+### OAuth browser window doesn't open
+
+Some browsers block popup windows from desktop apps. Quit the browser, reopen it, then click **Sign in with Claude** again. If it still doesn't open, run `claude login` directly in a terminal as a workaround.
+
+### "Permission denied" on macOS
+
+If the install script can't write to `~/.local/bin/`, your shell might be sandboxed. Try running the install command directly in Terminal.app rather than via the wizard. If `chmod` errors appear, run `chmod +w ~/.local/bin/` and retry.
+
+### Quota or rate-limit errors mid-chat
+
+Claude's per-account quota varies by plan. If you hit a quota wall, the streamed response stops and an error event appears in the chat. Wait a few minutes and retry, or upgrade your Claude.ai plan. Tallyfy Desktop doesn't add quota on top of Anthropic's; the limit is whatever your subscription says.
+
+### The model picker is empty
+
+This usually means the OAuth token expired. Click the user menu in the desktop app, choose **Sign out of Claude**, then click **Sign in with Claude** again.
+
+## What Claude can do that the others can't
+
+Claude is the most capable provider in Tallyfy Desktop v2.0.0:
+
+- **Tool use** - Claude can call MCP tools (Tallyfy's auto-injected MCP server) during the chat, not just at the end. You'll see `tool-use-start` and `tool-use-end` events stream in the chat.
+- **Thinking** - Claude streams its reasoning in a separate channel that's visible in the chat (collapsible).
+- **Cost reporting** - Claude reports the exact USD cost of each run on completion.
+- **Browser automation** - the `claude --chrome` flag drives a sandboxed Chrome instance for browser-bound workflows. See the [desktop repo's COMPUTER-USE-DEFERRED doc](https://github.com/tallyfy/desktop/blob/main/docs/COMPUTER-USE-DEFERRED.md) for what it can and can't do.
+- **Attachments** - drag a file into the chat and Claude reads it (limited to text and images in v1).
+
+The other providers cover subsets of these. See the [overview](/products/pro/integrations/tallyfy-desktop-ai/) for the full capability matrix.
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Overview</b>" href="/products/pro/integrations/tallyfy-desktop-ai/" > What Tallyfy Desktop is, what the AI Surface Pivot brought in v2.0.0, and why every AI run becomes a Tallyfy task. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Codex</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-codex/" > Install the OpenAI Codex CLI via npm and sign in with your ChatGPT subscription. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Gemini</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-gemini/" > Install the Google Gemini CLI via npm and complete the OAuth flow. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Task Intent Widget</b>" href="/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/" > The widget that turns AI chat into Tallyfy tasks, process launches, and template edits with one click. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-codex.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-codex.mdx
@@ -2,7 +2,7 @@
 about_tallyfy: true
 description: Install the OpenAI Codex CLI via npm and sign into your ChatGPT subscription so Tallyfy Desktop can drive it. The Install Wizard handles npm with explicit consent, or you can install manually with `npm install -g @openai/codex`.
 sidebar:
-  order: 11
+  order: 3
   label: Connect Codex
 title: Connect Codex to Tallyfy Desktop
 ---
@@ -10,7 +10,7 @@ title: Connect Codex to Tallyfy Desktop
 import { Steps, CardGrid, LinkTitleCard } from "~/components";
 
 :::note[Subscription, not API key]
-Codex in Tallyfy Desktop uses OAuth via your ChatGPT account. The app never asks for an `OPENAI_API_KEY` and won't accept one. You need a ChatGPT Plus, Pro, Team, Enterprise, or Edu subscription. If you don't have one, sign up at [chatgpt.com](https://chatgpt.com) first.
+Codex in Tallyfy Desktop uses OAuth via your ChatGPT account. The app never asks for an `OPENAI_API_KEY` and won't accept one. You need a ChatGPT Plus, Pro, Team, Enterprise, or Edu subscription. If you don't have one, sign up at [chatgpt.com](https://chatgpt.com)<a href="https://chatgpt.com" rel="nofollow noopener noreferrer" target="_blank"><sup>[1]</sup></a> first.
 :::
 
 ## What gets installed
@@ -79,7 +79,7 @@ The binary lands in your global npm prefix (typically `/opt/homebrew/bin/codex` 
    npm install -g @openai/codex
    ```
 
-   If npm reports a permission error, your npm prefix is likely system-owned. Either reconfigure npm to use a user-owned prefix (recommended; see [npm docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)) or run with `sudo`. Tallyfy Desktop never uses `sudo`; the wizard fails cleanly in that case.
+   If npm reports a permission error, your npm prefix is likely system-owned. Either reconfigure npm to use a user-owned prefix (recommended; see [npm docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)<a href="https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally" rel="nofollow noopener noreferrer" target="_blank"><sup>[2]</sup></a>) or run with `sudo`. Tallyfy Desktop never uses `sudo`; the wizard fails cleanly in that case.
 
 2. **Sign in**
 
@@ -126,8 +126,8 @@ The desktop app caches detection for 60 minutes. Cmd+Shift+R (Ctrl+Shift+R on Wi
 
 Your npm prefix is system-owned. The two clean fixes are:
 
-1. **Switch to a user-owned prefix** (recommended): see [npm's official fix](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally). After reconfiguring, re-run the wizard.
-2. **Use nvm** to manage Node.js: nvm puts npm in your home directory, sidestepping the issue. Install nvm from [nvm-sh/nvm](https://github.com/nvm-sh/nvm), then reinstall Node.js via `nvm install 20`.
+1. **Switch to a user-owned prefix** (recommended): see [npm's official fix](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)<a href="https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally" rel="nofollow noopener noreferrer" target="_blank"><sup>[3]</sup></a>. After reconfiguring, re-run the wizard.
+2. **Use nvm** to manage Node.js: nvm puts npm in your home directory, sidestepping the issue. Install nvm from [nvm-sh/nvm](https://github.com/nvm-sh/nvm)<a href="https://github.com/nvm-sh/nvm" rel="nofollow noopener noreferrer" target="_blank"><sup>[4]</sup></a>, then reinstall Node.js via `nvm install 20`.
 
 Don't run the wizard with `sudo`; the desktop app won't do that for you and it creates permission problems later.
 

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-codex.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-codex.mdx
@@ -1,0 +1,173 @@
+---
+about_tallyfy: true
+description: Install the OpenAI Codex CLI via npm and sign into your ChatGPT subscription so Tallyfy Desktop can drive it. The Install Wizard handles npm with explicit consent, or you can install manually with `npm install -g @openai/codex`.
+sidebar:
+  order: 11
+  label: Connect Codex
+title: Connect Codex to Tallyfy Desktop
+---
+
+import { Steps, CardGrid, LinkTitleCard } from "~/components";
+
+:::note[Subscription, not API key]
+Codex in Tallyfy Desktop uses OAuth via your ChatGPT account. The app never asks for an `OPENAI_API_KEY` and won't accept one. You need a ChatGPT Plus, Pro, Team, Enterprise, or Edu subscription. If you don't have one, sign up at [chatgpt.com](https://chatgpt.com) first.
+:::
+
+## What gets installed
+
+Tallyfy Desktop drives Codex through OpenAI's official `codex` command-line tool (the `@openai/codex` npm package). On first launch, the desktop app checks whether `codex` is on your `PATH` and whether you've signed in. If either is missing, it offers to install or guide you.
+
+The install command per platform is baked into the desktop app source code:
+
+| Platform | Command |
+|---|---|
+| macOS | `npm install -g @openai/codex` |
+| Linux | `npm install -g @openai/codex` |
+| Windows | `npm install -g @openai/codex` |
+
+The binary lands in your global npm prefix (typically `/opt/homebrew/bin/codex` on macOS-arm64 with Homebrew, or `/usr/local/bin/codex` with classic npm). You'll need Node.js 18+ already installed.
+
+## Prerequisites
+
+- A Tallyfy account (you'll sign in to Tallyfy Desktop first)
+- A ChatGPT Plus, Pro, Team, Enterprise, or Edu subscription
+- Node.js 18 or higher with `npm` available on `PATH`
+- A modern web browser for the OAuth sign-in step
+
+## Option A: Install Wizard (recommended)
+
+<Steps>
+
+1. **Open the Codex tab**
+
+   In Tallyfy Desktop, click the **Codex** tab. If the CLI isn't installed, the Install Wizard appears.
+
+2. **Read the consent screen**
+
+   The wizard shows the exact npm command and its risks:
+   - Modifies your global npm prefix
+   - May require `sudo` if your npm prefix is system-owned (uncommon with Homebrew or nvm)
+   - After install, you must run `codex login` interactively before headless use; otherwise calls return HTTP 401
+
+3. **Hold Shift for three seconds**
+
+   The button activates only while you hold Shift. Release to cancel.
+
+4. **Watch the progress log**
+
+   The wizard streams `npm install` output. You'll see the package download, dependency resolution, and a "Installed Codex vX.Y.Z" verification line.
+
+5. **Sign in with ChatGPT**
+
+   After install, click **Sign in with ChatGPT**. The desktop app runs `codex login`, which opens OpenAI's OAuth flow in your default browser. Approve the connection and return to the desktop app.
+
+   The token is stored under `~/.codex/auth.json`. The desktop app reads it from there.
+
+6. **Test the connection**
+
+   Type `hi` in the Codex tab and press Enter. You should see Codex's streamed response within a few seconds.
+
+</Steps>
+
+## Option B: Manual install
+
+<Steps>
+
+1. **Install via npm**
+
+   ```bash
+   npm install -g @openai/codex
+   ```
+
+   If npm reports a permission error, your npm prefix is likely system-owned. Either reconfigure npm to use a user-owned prefix (recommended; see [npm docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)) or run with `sudo`. Tallyfy Desktop never uses `sudo`; the wizard fails cleanly in that case.
+
+2. **Sign in**
+
+   ```bash
+   codex login
+   ```
+
+   This opens OpenAI's OAuth flow in your browser. Approve and return to the terminal.
+
+3. **Restart Tallyfy Desktop**
+
+   Quit fully and reopen. The Codex tab will detect the binary and skip the wizard.
+
+</Steps>
+
+## First chat
+
+Once Codex is connected:
+
+1. Click the **Codex** tab.
+2. The model picker shows the default (GPT-5.5 in v2.0.0).
+3. Type your message and press Enter. Codex streams plain-text responses, so you'll see the text appear chunk by chunk.
+
+Codex doesn't support MCP in v1, so the [Tallyfy MCP server](/products/pro/integrations/mcp-server/) isn't auto-injected as a tool. Instead, the desktop app prepends a system prompt that gives Codex your Tallyfy context (your org name, your role, links to your active processes). You can still trigger the [Task Intent Widget](/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/) from Codex chats; the widget watches for intent in the text Codex generates.
+
+## Verifying the install yourself
+
+```bash
+# Is the binary on PATH?
+which codex
+
+# Does it run?
+codex --version
+
+# Are you signed in?
+test -f ~/.codex/auth.json && echo "signed in" || echo "not signed in"
+```
+
+The desktop app caches detection for 60 minutes. Cmd+Shift+R (Ctrl+Shift+R on Windows/Linux) inside the Codex tab forces a re-detection.
+
+## Troubleshooting
+
+### `npm install` fails with EACCES
+
+Your npm prefix is system-owned. The two clean fixes are:
+
+1. **Switch to a user-owned prefix** (recommended): see [npm's official fix](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally). After reconfiguring, re-run the wizard.
+2. **Use nvm** to manage Node.js: nvm puts npm in your home directory, sidestepping the issue. Install nvm from [nvm-sh/nvm](https://github.com/nvm-sh/nvm), then reinstall Node.js via `nvm install 20`.
+
+Don't run the wizard with `sudo`; the desktop app won't do that for you and it creates permission problems later.
+
+### "HTTP 401 Unauthorized" in the chat
+
+You haven't run `codex login` yet, or the OAuth token expired. From a terminal:
+
+```bash
+codex login
+```
+
+Approve in the browser. Then go back to Tallyfy Desktop and press Cmd+Shift+R in the Codex tab to refresh detection.
+
+### Codex hangs and produces no output
+
+This is the classic stdin issue. Codex's CLI treats open stdin as input to append to the prompt; without proper stdin redirection it can wait forever. Tallyfy Desktop closes stdin correctly when it spawns Codex, so you shouldn't hit this from inside the app. If you do, the chat will time out after the default 5 minutes and emit an error event. Try the prompt again; the issue is usually transient.
+
+### "Codex tab shows installed but won't chat"
+
+Run `codex doctor` in a terminal. It reports the auth state, the model availability, and any account-level restrictions. If it says "authenticated, no model access," your ChatGPT plan doesn't include API access; upgrade to Plus, Pro, or higher.
+
+## What Codex covers in v1
+
+| Capability | Status |
+|---|---|
+| Streaming text responses | Yes (plain text per line) |
+| MCP tool use | No (Codex CLI doesn't support MCP in v1; planned for v2) |
+| Cost reporting | No (Codex charges against your ChatGPT subscription, no per-call cost is surfaced) |
+| Thinking events | No |
+| File attachments | No (v1) |
+| Browser automation | No |
+| Tallyfy context injection | Yes (via system-prompt prefix instead of MCP) |
+| Task Intent Widget | Yes (regex-based detection on Codex output) |
+
+If you need MCP tool use today, use Claude or Gemini instead; both have full MCP support in v1.
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Overview</b>" href="/products/pro/integrations/tallyfy-desktop-ai/" > What Tallyfy Desktop is, the four AI tabs, the Task Intent Widget, and why every AI run becomes a Tallyfy task. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Claude</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-claude/" > Install the Anthropic Claude CLI and sign in with your Claude.ai subscription. The most capable provider in v1. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Gemini</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-gemini/" > Install the Google Gemini CLI via npm and complete the OAuth flow. Full MCP support, no cost reporting in v1. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Task Intent Widget</b>" href="/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/" > The widget that turns AI chat into Tallyfy tasks, process launches, and template edits with one click. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-gemini.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-gemini.mdx
@@ -1,0 +1,179 @@
+---
+about_tallyfy: true
+description: Install the Google Gemini CLI via npm and sign into your Google account so Tallyfy Desktop can drive it. The Install Wizard handles npm with explicit consent, and the default model is `gemini-2.5-flash` to avoid subscription quota friction.
+sidebar:
+  order: 12
+  label: Connect Gemini
+title: Connect Gemini to Tallyfy Desktop
+---
+
+import { Steps, CardGrid, LinkTitleCard } from "~/components";
+
+:::note[Subscription, not API key]
+Gemini in Tallyfy Desktop uses OAuth via your Google account. The app never asks for a `GOOGLE_API_KEY` or `GEMINI_API_KEY` and won't accept either. A Google account is required (Workspace or personal Gmail both work); your usage counts against the free or paid Gemini quota tied to that account.
+:::
+
+## What gets installed
+
+Tallyfy Desktop drives Gemini through Google's official `gemini` command-line tool (the `@google/gemini-cli` npm package). On first launch, the desktop app checks whether `gemini` is on your `PATH` and whether you've signed in. If either is missing, it offers to install or guide you.
+
+The install command per platform is baked into the desktop app source code:
+
+| Platform | Command |
+|---|---|
+| macOS | `npm install -g @google/gemini-cli` |
+| Linux | `npm install -g @google/gemini-cli` |
+| Windows | `npm install -g @google/gemini-cli` |
+
+The binary lands in your global npm prefix. You'll need Node.js 18+ already installed.
+
+## Prerequisites
+
+- A Tallyfy account
+- A Google account (Workspace or personal Gmail)
+- Node.js 18 or higher with `npm` available on `PATH`
+- A modern web browser for the OAuth sign-in step
+
+## Option A: Install Wizard (recommended)
+
+<Steps>
+
+1. **Open the Gemini tab**
+
+   Click the **Gemini** tab in Tallyfy Desktop. If the CLI isn't installed, the Install Wizard appears.
+
+2. **Read the consent screen**
+
+   The wizard shows the npm command and the risks:
+   - Modifies your global npm prefix
+   - After install, run `gemini` once to complete the interactive OAuth flow
+   - Default model is `gemini-2.5-flash` (chosen to avoid subscription quota issues hit by `gemini-3-pro-preview`)
+
+3. **Hold Shift for three seconds**
+
+   The button activates while you hold Shift. Release to cancel.
+
+4. **Watch the progress log**
+
+   The wizard streams `npm install` output. You'll see the package install and a verification run of `gemini --version`.
+
+5. **Sign in with Google**
+
+   Click **Sign in with Google**. The desktop app runs `gemini` interactively for the first time, which kicks off Google's OAuth flow in your browser. Pick your account, approve the scopes, and return to the desktop app.
+
+   The token is stored under `~/.gemini/oauth_creds.json`. The desktop app reads it from there.
+
+6. **Test the connection**
+
+   Type `hi` in the Gemini tab and press Enter. You should see Gemini's streamed response within a few seconds.
+
+</Steps>
+
+## Option B: Manual install
+
+<Steps>
+
+1. **Install via npm**
+
+   ```bash
+   npm install -g @google/gemini-cli
+   ```
+
+2. **Run `gemini` once**
+
+   ```bash
+   gemini
+   ```
+
+   This triggers the OAuth flow in your browser. Pick your Google account, approve, and return to the terminal. The CLI saves credentials and exits.
+
+3. **Restart Tallyfy Desktop**
+
+   Quit fully and reopen. The Gemini tab will detect the binary and the credentials, then skip the wizard.
+
+</Steps>
+
+## First chat
+
+Once Gemini is connected:
+
+1. Click the **Gemini** tab.
+2. The model picker shows the default (`gemini-2.5-flash` in v2.0.0).
+3. Type your message and press Enter. Gemini streams NDJSON events, so you'll see the response appear chunk by chunk with token-count stats on completion.
+
+Because the [Tallyfy MCP server](/products/pro/integrations/mcp-server/) is auto-injected, Gemini knows about your tasks, processes, templates, and team. Try:
+
+- "What templates do we have for new-hire onboarding?"
+- "Find all overdue tasks assigned to me"
+- "Launch the customer feedback survey for last month's signups"
+
+The [Task Intent Widget](/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/) works the same way it does with Claude; intent is detected and the widget surfaces inline.
+
+## Why `gemini-2.5-flash` is the default
+
+The Gemini CLI's default model is `gemini-3-pro-preview`. In testing, that model hits "You have exhausted your capacity on this model" on most accounts after only a few prompts. Tallyfy Desktop ships with `gemini-2.5-flash` as the default to avoid that friction. You can switch to any other Gemini model from the model picker; if you hit the quota wall, switch back to `flash`.
+
+## Verifying the install yourself
+
+```bash
+# Is the binary on PATH?
+which gemini
+
+# Does it run?
+gemini --version
+
+# Are you signed in?
+test -f ~/.gemini/oauth_creds.json && echo "signed in" || echo "not signed in"
+```
+
+Cmd+Shift+R (Ctrl+Shift+R on Windows/Linux) in the Gemini tab forces a re-detection.
+
+## Troubleshooting
+
+### "You have exhausted your capacity on this model"
+
+You're hitting Google's subscription quota. The CLI auto-retries with backoff (10s, 20s, 40s) up to five attempts. If the retries don't work:
+
+1. Switch to `gemini-2.5-flash` in the model picker; it has a higher free-tier limit
+2. Wait a few minutes for the quota to reset
+3. Upgrade your Google AI plan if you need higher throughput
+
+This is Google's limit, not Tallyfy's; the desktop app surfaces it cleanly but can't bypass it.
+
+### `npm install` fails with EACCES
+
+Same fix as Codex: switch to a user-owned npm prefix or use nvm. See the [Codex install troubleshooting](/products/pro/integrations/tallyfy-desktop-ai/connect-codex/) for the same fix steps. Don't run the wizard with `sudo`.
+
+### OAuth browser window opens to an error page
+
+Google sometimes blocks OAuth requests from new clients. The fix:
+
+1. Sign into your Google account in the same browser first
+2. Then click **Sign in with Google** in Tallyfy Desktop
+
+If the error persists, run `gemini` directly in a terminal; the CLI gives a more specific error message there.
+
+### "Tools unavailable" warning at the start of a chat
+
+Gemini supports MCP, but the CLI loads MCP servers from a config file at `~/.gemini/settings.json`. Tallyfy Desktop writes a temporary MCP config per run (with your Tallyfy session token) and passes it to Gemini via the standard mechanism. If you see "Tools unavailable," check that you're on `gemini-cli` 0.17 or later: `gemini --version`. Older versions had bugs in MCP loading; upgrade with `npm install -g @google/gemini-cli@latest`.
+
+## What Gemini covers in v1
+
+| Capability | Status |
+|---|---|
+| Streaming text responses | Yes (NDJSON, full streaming with deltas) |
+| MCP tool use | Yes |
+| Cost reporting | No (only token counts) |
+| Thinking events | No |
+| File attachments | Yes |
+| Browser automation | No |
+| Tallyfy context injection | Yes (via MCP, like Claude) |
+| Task Intent Widget | Yes |
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Overview</b>" href="/products/pro/integrations/tallyfy-desktop-ai/" > What Tallyfy Desktop is, the four AI tabs, the Task Intent Widget, and why every AI run becomes a Tallyfy task. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Claude</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-claude/" > Install the Anthropic Claude CLI and sign in with your Claude.ai subscription. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Codex</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-codex/" > Install the OpenAI Codex CLI via npm and sign in with your ChatGPT subscription. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Ollama</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-ollama/" > Install Ollama locally and run open-source models entirely on your machine. No subscription needed. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-gemini.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-gemini.mdx
@@ -2,7 +2,7 @@
 about_tallyfy: true
 description: Install the Google Gemini CLI via npm and sign into your Google account so Tallyfy Desktop can drive it. The Install Wizard handles npm with explicit consent, and the default model is `gemini-2.5-flash` to avoid subscription quota friction.
 sidebar:
-  order: 12
+  order: 4
   label: Connect Gemini
 title: Connect Gemini to Tallyfy Desktop
 ---

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-ollama.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-ollama.mdx
@@ -1,0 +1,206 @@
+---
+about_tallyfy: true
+description: Install Ollama on your local machine and run open-source models entirely offline. The Install Wizard handles `brew install` on macOS, the shell installer on Linux, and `winget` on Windows, then pulls a default model.
+sidebar:
+  order: 13
+  label: Connect Ollama
+title: Connect Ollama to Tallyfy Desktop
+---
+
+import { Steps, CardGrid, LinkTitleCard } from "~/components";
+
+:::note[No subscription, no cloud]
+Ollama runs entirely on your local machine. There's no account, no OAuth flow, and no subscription. Your prompts and responses never leave your computer. The only thing Tallyfy Desktop sends to the cloud is the metadata for the Tallyfy task that wraps each run (provider, model, prompt summary, duration).
+:::
+
+## What gets installed
+
+Tallyfy Desktop drives Ollama through the local daemon at `http://127.0.0.1:11434`. Unlike the other three providers, Ollama isn't a CLI you spawn per-run; it's a background service that listens on a port and accepts HTTP requests. Tallyfy Desktop talks to that service directly.
+
+The install command per platform is baked into the desktop app source code:
+
+| Platform | Command |
+|---|---|
+| macOS | `brew install ollama && brew services start ollama` |
+| Linux | `curl -fsSL https://ollama.com/install.sh \| sh` |
+| Windows | `winget install --silent --accept-source-agreements --accept-package-agreements Ollama.Ollama` |
+
+After install, Ollama runs as a background service that starts on login (macOS, Linux) or on boot (Windows). It listens only on `127.0.0.1`, so other machines on your network can't reach it.
+
+## Prerequisites
+
+- A Tallyfy account
+- Enough RAM and disk space for the model you want to run (the default `llama3.2:1b` needs around 2 GB RAM and 1.3 GB disk)
+- Homebrew (macOS), curl (Linux), or winget (Windows)
+
+## Option A: Install Wizard (recommended)
+
+<Steps>
+
+1. **Open the Ollama tab**
+
+   Click the **Ollama** tab in Tallyfy Desktop. If Ollama isn't installed or the daemon isn't running, the Install Wizard appears.
+
+2. **Read the consent screen**
+
+   The wizard shows the exact command per platform and lists the risks:
+   - **macOS**: requires Homebrew; starts a launchd service `homebrew.mxcl.ollama` that listens on `127.0.0.1:11434` and auto-starts on login
+   - **Linux**: creates a systemd unit `ollama.service` (requires `sudo` for service registration)
+   - **Windows**: installs via winget (Windows Package Manager); the service listens on `127.0.0.1:11434`
+
+3. **Hold Shift for three seconds**
+
+   The button activates while you hold Shift.
+
+4. **Watch the progress log**
+
+   The wizard streams installer output. On macOS you'll see Homebrew's download and link steps, plus the `brew services start ollama` line. On Linux you'll see the install script's output. On Windows you'll see winget's progress.
+
+5. **Pull the default model**
+
+   After install, the wizard prompts you to pull a default model. The Tallyfy Desktop default is `llama3.2:1b` (1.2 billion parameters, around 1.3 GB on disk). The pull runs in the wizard with a progress bar.
+
+   You can pull a bigger or smaller model later; this is just the cold-start choice.
+
+6. **Test the connection**
+
+   Type `hi` in the Ollama tab and press Enter. You should see the streamed response within a few seconds (latency depends on your CPU/GPU).
+
+</Steps>
+
+## Option B: Manual install
+
+<Steps>
+
+1. **Install Ollama**
+
+   - **macOS**: `brew install ollama && brew services start ollama`
+   - **Linux**: `curl -fsSL https://ollama.com/install.sh | sh`
+   - **Windows**: `winget install Ollama.Ollama`
+
+2. **Pull a model**
+
+   ```bash
+   ollama pull llama3.2:1b
+   ```
+
+   Or pick any other model from [ollama.com/library](https://ollama.com/library). Larger models (`llama3.1:70b`, `mixtral:8x7b`, etc.) need substantially more RAM.
+
+3. **Verify the daemon is running**
+
+   ```bash
+   curl http://127.0.0.1:11434/api/tags
+   ```
+
+   You should see a JSON response listing your installed models.
+
+4. **Restart Tallyfy Desktop**
+
+   Quit fully and reopen. The Ollama tab will detect the daemon and the model.
+
+</Steps>
+
+## First chat
+
+Once Ollama is connected:
+
+1. Click the **Ollama** tab.
+2. The model picker shows the models you've pulled. Pick one.
+3. Type your message and press Enter.
+
+First responses are slower because Ollama loads the model into RAM on the first request. After that, it stays loaded for a few minutes and responses are fast.
+
+## What Ollama can and can't do in v1
+
+Ollama runs local open-source models, which have real limits compared to Claude, Codex, or Gemini:
+
+| Capability | Status |
+|---|---|
+| Streaming text responses | Yes (NDJSON streaming) |
+| MCP tool use | Degraded (no native MCP; falls back to system-prompt prefix with Tallyfy context) |
+| Cost reporting | N/A (always 0; local compute) |
+| Thinking events | No |
+| File attachments | No |
+| Browser automation | No |
+| Tallyfy context injection | Yes (via system-prompt prefix) |
+| Task Intent Widget | Yes |
+
+The Task Intent Widget still works because it watches the model's text output for intent patterns; it doesn't need MCP. So a small local model can still trigger a task creation when you ask for one.
+
+## Choosing a model
+
+Tallyfy Desktop defaults to `llama3.2:1b`. That's a deliberate trade-off: small enough to run on any modern laptop, fast enough to feel responsive, but obviously less capable than larger models.
+
+A few common choices, in increasing size and capability:
+
+- `llama3.2:1b` (~1.3 GB) - the default; very fast, modest reasoning
+- `llama3.2:3b` (~2 GB) - better at instructions, still fast on most hardware
+- `mistral:7b` (~4 GB) - solid general-purpose model, needs 8+ GB RAM
+- `llama3.1:8b` (~5 GB) - higher quality, slower; 16+ GB RAM recommended
+- `qwen2.5-coder:7b` (~5 GB) - tuned for code; useful if you're using Ollama for development tasks
+
+Pull any of these with `ollama pull <model>`, then pick it from the model picker. Larger models give better answers; smaller models give faster ones. There's no subscription cost, just disk and RAM.
+
+## Privacy guarantee
+
+The whole point of Ollama is privacy. Tallyfy Desktop preserves this:
+
+1. **Your prompts** go from the desktop app to `127.0.0.1:11434` on the same machine. They never touch the internet.
+2. **Model responses** come back from the same local daemon.
+3. **Tallyfy task metadata** (provider="ollama", model="...", prompt summary, duration) gets sent to Tallyfy as a row in the "AI Runs" checklist. The same metadata as any other run.
+
+If you want to run truly offline (no network at all, even for Tallyfy), the desktop app will queue the Tallyfy task creation and retry when network comes back. The AI run itself completes immediately.
+
+## Verifying the install yourself
+
+```bash
+# Is the binary on PATH?
+which ollama
+
+# Does it run?
+ollama --version
+
+# Is the daemon up?
+curl -sf http://127.0.0.1:11434/api/tags || echo "daemon not running"
+
+# What models are pulled?
+ollama list
+```
+
+If the daemon isn't running:
+
+- **macOS**: `brew services start ollama` (or `brew services restart ollama` if it's wedged)
+- **Linux**: `sudo systemctl start ollama`
+- **Windows**: open Services, find "Ollama", and start it
+
+Then press Cmd+Shift+R (Ctrl+Shift+R) in the Ollama tab to retry detection.
+
+## Troubleshooting
+
+### "Daemon not running" but the binary is installed
+
+The Ollama service might be stopped. Run the platform-specific start command above. If it still won't start, check the logs:
+
+- **macOS**: `~/Library/Logs/Homebrew/ollama/`
+- **Linux**: `journalctl -u ollama -n 100`
+- **Windows**: Event Viewer, Windows Logs, Application
+
+### Out-of-memory error mid-chat
+
+You pulled a model bigger than your RAM. Switch to a smaller model from the picker, or pull a quantized variant (e.g., `llama3.1:8b-q4_0` instead of `llama3.1:8b`).
+
+### Very slow first response
+
+Ollama loads the model from disk on the first request. For larger models this can take 10-30 seconds. Subsequent requests are fast. If you have a GPU (Apple Silicon, NVIDIA CUDA), Ollama uses it automatically; check `ollama ps` to see which device the model is loaded on.
+
+### "Model not found" when picking a model
+
+You haven't pulled it yet. From a terminal: `ollama pull <model>`. The download progress appears in the terminal; the model becomes available in Tallyfy Desktop once it finishes (you may need Cmd+Shift+R to refresh the picker).
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Overview</b>" href="/products/pro/integrations/tallyfy-desktop-ai/" > What Tallyfy Desktop is, the four AI tabs, the Task Intent Widget, and why every AI run becomes a Tallyfy task. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Claude</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-claude/" > Install the Anthropic Claude CLI and sign in with your Claude.ai subscription. The most capable cloud provider. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Terminal Jobs</b>" href="/products/pro/integrations/tallyfy-desktop-ai/terminal-jobs/" > Track every AI run, view output, cancel running jobs. Works for Ollama runs the same as cloud runs. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Task Intent Widget</b>" href="/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/" > The widget that turns AI chat into Tallyfy tasks. Works with local Ollama models because it watches text output, not MCP tool calls. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-ollama.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/connect-ollama.mdx
@@ -2,7 +2,7 @@
 about_tallyfy: true
 description: Install Ollama on your local machine and run open-source models entirely offline. The Install Wizard handles `brew install` on macOS, the shell installer on Linux, and `winget` on Windows, then pulls a default model.
 sidebar:
-  order: 13
+  order: 5
   label: Connect Ollama
 title: Connect Ollama to Tallyfy Desktop
 ---
@@ -84,7 +84,7 @@ After install, Ollama runs as a background service that starts on login (macOS, 
    ollama pull llama3.2:1b
    ```
 
-   Or pick any other model from [ollama.com/library](https://ollama.com/library). Larger models (`llama3.1:70b`, `mixtral:8x7b`, etc.) need substantially more RAM.
+   Or pick any other model from [ollama.com/library](https://ollama.com/library)<a href="https://ollama.com/library" rel="nofollow noopener noreferrer" target="_blank"><sup>[1]</sup></a>. Larger models (`llama3.1:70b`, `mixtral:8x7b`, etc.) need substantially more RAM.
 
 3. **Verify the daemon is running**
 

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/index.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/index.mdx
@@ -9,7 +9,7 @@ title: Tallyfy Desktop AI surface
 import { CardGrid, LinkTitleCard } from "~/components";
 
 :::note[What this section covers]
-End-user docs for the AI surface in Tallyfy Desktop v2.0.0. If you want to know what each tab does, how to connect Claude, Codex, Gemini, or Ollama, what the Task Intent Widget does, and how Terminal Jobs tracks every run, you're in the right place. Internal architecture references (the `AIProvider` contract, IPC channels, the SQLite schema) stay in the desktop repo under [`docs/AI-ARCHITECTURE.md`](https://github.com/tallyfy/desktop/blob/main/docs/AI-ARCHITECTURE.md) and [`docs/PROVIDER-MATRIX.md`](https://github.com/tallyfy/desktop/blob/main/docs/PROVIDER-MATRIX.md).
+End-user docs for the AI surface in Tallyfy Desktop v2.0.0. If you want to know what each tab does, how to connect Claude, Codex, Gemini, or Ollama, what the Task Intent Widget does, and how Terminal Jobs tracks every run, you're in the right place. Internal architecture references (the `AIProvider` contract, IPC channels, the SQLite schema) stay in the desktop repo under [`docs/AI-ARCHITECTURE.md`](https://github.com/tallyfy/desktop/blob/main/docs/AI-ARCHITECTURE.md)<a href="https://github.com/tallyfy/desktop/blob/main/docs/AI-ARCHITECTURE.md" rel="nofollow noopener noreferrer" target="_blank"><sup>[1]</sup></a> and [`docs/PROVIDER-MATRIX.md`](https://github.com/tallyfy/desktop/blob/main/docs/PROVIDER-MATRIX.md)<a href="https://github.com/tallyfy/desktop/blob/main/docs/PROVIDER-MATRIX.md" rel="nofollow noopener noreferrer" target="_blank"><sup>[2]</sup></a>.
 :::
 
 ## What Tallyfy Desktop is

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/index.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/index.mdx
@@ -1,0 +1,122 @@
+---
+about_tallyfy: true
+description: Tallyfy Desktop v2.0.0 is a multi-tab AI-first app that pairs four AI assistants (Claude, Codex, Gemini, Ollama) with your Tallyfy workspace. Every AI run becomes a tracked task, the Tallyfy MCP server is auto-injected, and an inline widget turns chat into Tallyfy work.
+sidebar:
+  order: 1
+title: Tallyfy Desktop AI surface
+---
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+:::note[What this section covers]
+End-user docs for the AI surface in Tallyfy Desktop v2.0.0. If you want to know what each tab does, how to connect Claude, Codex, Gemini, or Ollama, what the Task Intent Widget does, and how Terminal Jobs tracks every run, you're in the right place. Internal architecture references (the `AIProvider` contract, IPC channels, the SQLite schema) stay in the desktop repo under [`docs/AI-ARCHITECTURE.md`](https://github.com/tallyfy/desktop/blob/main/docs/AI-ARCHITECTURE.md) and [`docs/PROVIDER-MATRIX.md`](https://github.com/tallyfy/desktop/blob/main/docs/PROVIDER-MATRIX.md).
+:::
+
+## What Tallyfy Desktop is
+
+Tallyfy Desktop is a cross-platform Electron app for macOS, Windows, and Linux. v1 of the app was a thin shell around the Tallyfy web client. v2.0.0 is a different product: an AI-first surface that hosts four AI assistants side-by-side in a tabbed window, with your Tallyfy workspace as the system of record.
+
+Think of it as a single window where you can talk to Claude in one tab, Gemini in another, and keep an eye on a long-running Ollama job in a third, while every conversation you have can create a Tallyfy task, launch a process, or edit a template with one click.
+
+![Tallyfy Desktop showing four AI tabs and the Task Intent Widget inline in a chat bubble](https://screenshots.tallyfy.com/desktop-ai/overview-screenshot.png)
+
+## What v2.0.0 brought in
+
+The AI Surface Pivot landed seven user-visible changes. Each is documented in its own article in this section.
+
+### 1. Four provider tabs
+
+The window has a tab for each AI assistant Tallyfy Desktop supports:
+
+- **Claude** (Anthropic) - the most capable provider for tool use, thinking, and browser automation
+- **Codex** (OpenAI) - text streaming via the official `codex` CLI
+- **Gemini** (Google) - streaming chat with MCP support
+- **Ollama** (local) - your own models, running entirely on your machine
+
+Each tab is its own conversation. Switching tabs doesn't lose context. The tab strip shows which providers are installed and signed in, so you can tell at a glance which assistant is ready to use.
+
+Connect each one with its own short guide:
+
+- [Connect Claude](/products/pro/integrations/tallyfy-desktop-ai/connect-claude/)
+- [Connect Codex](/products/pro/integrations/tallyfy-desktop-ai/connect-codex/)
+- [Connect Gemini](/products/pro/integrations/tallyfy-desktop-ai/connect-gemini/)
+- [Connect Ollama](/products/pro/integrations/tallyfy-desktop-ai/connect-ollama/)
+
+### 2. The Task Intent Widget
+
+The Task Intent Widget is the feature that turns chat into Tallyfy work. As you type with an AI, the desktop app watches for phrases like "create a task for John" or "let's run the onboarding process." When it spots an intent, it shows a one-click widget inline in the chat bubble that creates the task, launches the process, or edits the template in your Tallyfy account.
+
+Read the full [Task Intent Widget guide](/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/) for details on the four states, the per-intent prefill shapes, and how the two-stage detector keeps false positives down.
+
+### 3. Mandatory Tallyfy sign-in
+
+You sign into your Tallyfy account before any AI tab is visible. The app shows a single "Sign in with Tallyfy" screen on first launch. After sign-in, the app stores your session token in the OS keychain (Keychain on macOS, Credential Manager on Windows, Secret Service on Linux when available).
+
+Why? Because everything else in the app, from MCP injection to task wrapping to the intent widget, needs your Tallyfy identity. Letting the AI surfaces run without a Tallyfy account would mean the AI doesn't know who you are, what org you're in, or where to put the tasks it creates.
+
+### 4. Tallyfy MCP auto-injection
+
+Every AI chat in the desktop app gets the [Tallyfy MCP server](/products/pro/integrations/mcp-server/) auto-injected as its first MCP. You don't paste a URL into a config file. You don't run `claude mcp add`. The desktop app handles it behind the scenes using your Tallyfy session token.
+
+This means every AI tab knows about your tasks, processes, templates, members, and guests from the moment you open it. Ask Claude "what tasks do I have due this week?" and it answers without any setup.
+
+For Codex (no MCP support in v1) and Ollama (capability-degraded), the desktop app falls back to a system-prompt prefix that gives the AI the same Tallyfy context.
+
+### 5. System "AI Runs" checklist
+
+Every AI run becomes a Tallyfy task in a system checklist called "AI Runs." This is the v2.0.0 invariant: nothing the AI does is invisible. The task records the provider, the model, the prompt, the cost (where available), and the deep link back to the desktop app.
+
+If something goes wrong, the task stays. It's marked with the error code so you can see what happened from your Tallyfy account, days or weeks later, on any device. The desktop app stores the raw run events locally; the Tallyfy task is the cross-device authority of record.
+
+### 6. Local SQLite run history (Terminal Jobs tab)
+
+The Terminal Jobs tab is the desktop app's view of every AI run. It's a list, newest first, with status, duration, cost, and a button to view the full streamed output of any run. Read the [Terminal Jobs guide](/products/pro/integrations/tallyfy-desktop-ai/terminal-jobs/) for details.
+
+The data is stored in a local SQLite database on your machine. Run events never leave the device. The Tallyfy task row is the only cloud artifact, and it carries only the metadata you'd see in any other Tallyfy task.
+
+### 7. Auto-installer
+
+The first time you click on a provider tab whose CLI isn't installed, the desktop app shows an Install Wizard. It explains exactly what command will run, lists the risks (network egress, disk writes, service registration), and waits for you to hold the Shift key for three seconds before installing. After install, it verifies the binary works and reports back.
+
+The install commands are baked into the app source code (not fetched at runtime), so what you consent to is what runs. The exact commands per provider are listed in each provider's connect guide.
+
+## Subscription-only AI
+
+Tallyfy Desktop v2.0.0 does not accept API keys. You connect via your existing AI subscription:
+
+- **Claude** uses OAuth via your Claude.ai account (Pro, Max, Team, or Enterprise plan)
+- **Codex** uses OAuth via your ChatGPT account (Plus, Pro, Team, Enterprise, or Edu plan)
+- **Gemini** uses OAuth via your Google account
+- **Ollama** runs locally on your machine; no account, no subscription
+
+This is a deliberate design decision. API keys are long-lived secrets that easily leak; OAuth tokens are short-lived and scoped. The desktop app handles the OAuth flow for each provider through its official CLI, so you keep one billing relationship per provider and Tallyfy never sees your AI costs.
+
+## Privacy and data flow
+
+What the desktop app does with your data:
+
+1. Prompts you type go to the AI provider you selected. No interception. No copy.
+2. Streamed responses come back from the provider, render in the chat window, and are recorded in the local SQLite database.
+3. Run metadata (provider, model, prompt summary, cost, duration) is sent to Tallyfy as a task in the "AI Runs" checklist.
+4. Tallyfy state the AI reads or writes (tasks, processes, templates) goes through the Tallyfy MCP server and is logged in your existing Tallyfy audit trail.
+
+Ollama is the local case: everything stays on your machine. No prompts leave the device. The Tallyfy task is still created (because the run is still tracked), but the AI half of the conversation never touches a cloud.
+
+## What's next in this section
+
+| Article | What it covers |
+|---|---|
+| [Connect Claude](/products/pro/integrations/tallyfy-desktop-ai/connect-claude/) | Install the Claude CLI, sign in with OAuth, verify the connection |
+| [Connect Codex](/products/pro/integrations/tallyfy-desktop-ai/connect-codex/) | Install Codex via npm, sign in with `codex login`, verify |
+| [Connect Gemini](/products/pro/integrations/tallyfy-desktop-ai/connect-gemini/) | Install the Gemini CLI via npm, complete the OAuth flow, verify |
+| [Connect Ollama](/products/pro/integrations/tallyfy-desktop-ai/connect-ollama/) | Install Ollama locally, pull a model, verify the daemon |
+| [Task Intent Widget](/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/) | What the widget does, when it shows, how to use it |
+| [Terminal Jobs](/products/pro/integrations/tallyfy-desktop-ai/terminal-jobs/) | Track every AI run, view output, cancel running jobs |
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Integrations > MCP server</b>" href="/products/pro/integrations/mcp-server/" > Tallyfy's MCP Server lets you control workflows through plain English in any MCP-compatible AI client. The desktop app auto-injects this server into every chat. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Task Intent Widget</b>" href="/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/" > The Task Intent Widget watches your AI chat for task, process, and template intent, then offers a one-click affordance to create them in Tallyfy. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Terminal Jobs</b>" href="/products/pro/integrations/tallyfy-desktop-ai/terminal-jobs/" > Every AI run in the desktop app appears in the Terminal Jobs tab with full output, cost, and the option to cancel running jobs. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Claude</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-claude/" > Install the Claude CLI and sign in with your Claude.ai subscription. The desktop app drives the OAuth flow and verifies the connection on first run. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/index.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/index.mdx
@@ -102,6 +102,24 @@ What the desktop app does with your data:
 
 Ollama is the local case: everything stays on your machine. No prompts leave the device. The Tallyfy task is still created (because the run is still tracked), but the AI half of the conversation never touches a cloud.
 
+## First launch: OS security prompts (v2.0.0)
+
+v2.0.0 is not yet code-signed. The first time you open it, your operating system will warn you. This is expected. Here is what you will see and what to do.
+
+### macOS
+
+Double-clicking the app the first time shows: "Tallyfy cannot be opened because Apple cannot check it for malicious software." Click Cancel, then **right-click (or Control-click) the Tallyfy app and choose Open** from the menu. macOS shows a second prompt with an Open button. Click Open. After this one-time approval, you can launch normally. Apple Silicon Macs are stricter than Intel and always need this right-click path on first launch.
+
+### Windows
+
+Running the installer the first time shows: "Windows protected your PC. Microsoft Defender SmartScreen prevented an unrecognized app from starting." Click **More info** (the small link), then **Run anyway**. SmartScreen eases up after the binary builds reputation across enough machines.
+
+### Linux
+
+`.AppImage` and `.deb` install without OS security prompts. If the AppImage will not run, mark it executable: `chmod +x Tallyfy-2.0.0.AppImage`.
+
+Signed releases (which install silently) land in a future v2.0.x once we provision the certificate. Auto-update inside the app handles subsequent versions without prompts.
+
 ## What's next in this section
 
 | Article | What it covers |

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/task-intent-widget.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/task-intent-widget.mdx
@@ -2,7 +2,7 @@
 about_tallyfy: true
 description: The Task Intent Widget turns AI chat into Tallyfy work with one click. As you talk to Claude, Codex, Gemini, or Ollama, the widget watches for task, process, and template intent and surfaces an inline affordance to create them in Tallyfy.
 sidebar:
-  order: 21
+  order: 7
   label: Task Intent Widget
 title: Task Intent Widget
 ---
@@ -119,7 +119,7 @@ The detection cost when disabled is zero. The regex isn't even run.
 
 The widget is calibrated against a corpus of 100 example messages (30+ of which are negative examples like sarcasm, hypotheticals, or chit-chat that shouldn't trigger). The current calibration aims for precision >= 0.85 and recall >= 0.75 on that corpus.
 
-If you find the widget firing too often or too rarely on your messages, file an issue on the [desktop repo](https://github.com/tallyfy/desktop/issues) with the prompt text and what you expected. Real-world miscalibrations feed back into the test corpus.
+If you find the widget firing too often or too rarely on your messages, file an issue on the [desktop repo](https://github.com/tallyfy/desktop/issues)<a href="https://github.com/tallyfy/desktop/issues" rel="nofollow noopener noreferrer" target="_blank"><sup>[1]</sup></a> with the prompt text and what you expected. Real-world miscalibrations feed back into the test corpus.
 
 ## What it looks like in each provider
 

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/task-intent-widget.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/task-intent-widget.mdx
@@ -1,0 +1,145 @@
+---
+about_tallyfy: true
+description: The Task Intent Widget turns AI chat into Tallyfy work with one click. As you talk to Claude, Codex, Gemini, or Ollama, the widget watches for task, process, and template intent and surfaces an inline affordance to create them in Tallyfy.
+sidebar:
+  order: 21
+  label: Task Intent Widget
+title: Task Intent Widget
+---
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## What the widget does
+
+You're chatting with Claude about next quarter's hiring plan. You say "let's create a task for me to review the candidate pipeline on Friday." Without the Task Intent Widget, that's where it ends. You'd switch to Tallyfy in another browser tab, click "new task," fill in a form, copy details over.
+
+With the Task Intent Widget, a small box appears at the bottom of Claude's chat bubble. It shows the proposed task title and a "Create task" button. Click it. Done. The task is in Tallyfy, assigned to you, due Friday, with a deep link back to the conversation.
+
+![Task Intent Widget showing inline at the bottom of an AI chat bubble](https://screenshots.tallyfy.com/desktop-ai/task-intent-widget.png)
+
+This is the feature that makes Tallyfy Desktop different from any other AI chat app. Other chat apps end at the response. The Task Intent Widget closes the loop: AI suggests work, you confirm, Tallyfy tracks it.
+
+## Three kinds of intent
+
+The widget recognises three kinds of intent and shows a different prefill for each:
+
+| Intent | When it fires | What the widget creates |
+|---|---|---|
+| **Create task** | The AI suggests a single piece of work ("create a task to...", "remind me to...", "let's add a todo for...") | A new task in Tallyfy with title, optional assignee, optional deadline, optional priority |
+| **Launch process** | The AI suggests starting a workflow ("let's launch the customer onboarding process", "run the audit template for Q3", "kick off the review workflow") | A new process from an existing template, with the kickoff form pre-filled if the AI provided enough detail |
+| **Edit template** | The AI suggests modifying a workflow ("we should add a step for legal review", "let's update the onboarding template to include training") | A template edit (add step, remove step, edit step), opened in a side panel for confirmation |
+
+For each kind, the widget validates the intent against your Tallyfy permissions. If you can't edit templates, the "Edit template" widget never appears. If a process name resolves to a template you don't have access to, the widget shows an error and offers to ping the template owner.
+
+## Four widget states
+
+The widget transitions through four UI states based on what you do with it:
+
+1. **Collapsed** - the default state. Shows a one-line summary ("Create task: Review candidate pipeline Friday") and a primary button ("Create task"). About 40 pixels tall, so it doesn't dominate the chat bubble.
+
+2. **Expanded** - click the chevron or "edit" on the collapsed widget. Shows all the prefilled fields (title, description, assignee, deadline, priority for tasks; template, name, kickoff fields for processes; step change details for templates). You can tweak any field inline before confirming.
+
+3. **Modal** - if the prefill is complex (e.g., a process with five kickoff fields) or ambiguous (e.g., three templates match the AI's suggestion), the widget opens a full form modal. Same fields as expanded, but with more room and the ability to pick from a dropdown when there are multiple candidates.
+
+4. **Confirmation** - after you click the create button and Tallyfy responds with a 201. The widget replaces itself with a green check, the title of what got created, and a "View in Tallyfy" link that opens the new task or process.
+
+## How detection works
+
+The widget uses a two-stage pipeline so it's both fast and accurate.
+
+### Stage 1: regex (always on)
+
+As the AI streams text into the chat, a regex pattern matcher runs on each chunk. It looks for phrases that strongly suggest intent: "create a task", "add a todo", "let's launch", "we should add a step", and so on. Stage 1 is cheap, runs locally, and produces a confidence score of 0.7 for any hit.
+
+False positives are acceptable at this stage. If the widget shows up when you weren't asking for a task, click the X to dismiss it. The dismiss is sticky for that chat bubble; the widget won't reappear for the same span of text.
+
+### Stage 2: LLM extraction (Claude only, opt-in)
+
+For Claude conversations specifically, stage 2 fires after the AI finishes its message (debounced 500ms after the last text chunk). It asks Claude itself to look at the message and extract structured intent into a JSON envelope. This catches intent that regex misses ("we ought to look at..." doesn't match a regex but obviously means "create a task to look at...").
+
+Stage 2 runs only if:
+
+1. The provider supports tool use (Claude in v1)
+2. Stage 1 produced at least one hit on the message (to avoid LLM cost on chit-chat)
+3. You haven't disabled it in settings (default on for Claude, off for everything else)
+
+When stage 1 and stage 2 disagree, stage 2 wins (it's the more accurate signal). The widget updates in place; no flicker.
+
+For Codex, Gemini, and Ollama, only stage 1 runs. Stage 2 will arrive in v2 when those providers stabilise their tool-use semantics.
+
+## Privacy
+
+Stage 1 runs entirely on your machine. The regex patterns are baked into the desktop app source code; no remote calls.
+
+Stage 2 (Claude only) uses the same provider you're already chatting with. The extraction call is one extra prompt to Claude per message, charged to your Claude subscription (typically less than a cent per call because the extraction prompt is short). The call uses the same API session as your chat; no new authentication, no new endpoint.
+
+Tallyfy itself sees only the final action: a `POST /api/tasks`, a `POST /api/checklists/<id>/runs`, or a `PATCH /api/checklists/<id>/steps/<stepId>`. The widget doesn't send your prompt text to Tallyfy. The widget doesn't log to a third-party telemetry endpoint.
+
+## Resolving ambiguous intent
+
+A common case: you say "launch the onboarding process" and you have three templates whose names contain "onboarding" (customer, employee, vendor). The widget can't pick blindly.
+
+Here's what happens:
+
+1. The widget detects the intent and tries to resolve the template name with a fuzzy substring search against your accessible templates
+2. If zero templates match, the widget shows an error: "No template matches 'onboarding'. Pick one from the list?"
+3. If one template matches with high confidence, the widget uses it and shows the name in the prefill
+4. If multiple templates match (2-5), the widget escalates to the modal state and shows them all with the best match pre-selected
+5. If too many match (>5), the modal shows a search box
+
+The same pattern applies to assignees ("create a task for John" with two Johns in your org) and templates for edits.
+
+## What happens after you click "Create"
+
+The widget calls Tallyfy's API behind the scenes. The exact endpoint depends on the intent:
+
+| Intent | Endpoint |
+|---|---|
+| Create task | `POST /api/tasks` |
+| Launch process | `POST /api/checklists/<templateId>/runs` (with `templateId` resolved from the template name, if needed) |
+| Edit template | `PATCH /api/checklists/<templateId>/steps/<stepId>` |
+
+The Tallyfy task or process is tagged with metadata that identifies the source: provider id, model name, run id (so you can trace it back to the Terminal Jobs entry), and a flag `source: 'desktop-intent-widget'`. This makes it easy to audit AI-generated work later: filter the Tasks view by that source tag.
+
+On success (HTTP 201), the widget transitions to the confirmation state. The deep link goes to the new item; you can pick whether it opens in the desktop app (`tallyfy://desktop-task/<id>`) or in your browser (`https://go.tallyfy.com/...`).
+
+On failure (HTTP 4xx or 5xx), the widget shows an error state with the API error message and a "Retry" button. It does *not* collapse back; you already committed to creating something, so the widget stays visible until you either succeed or dismiss.
+
+## Disabling the widget
+
+Some users don't want the widget to fire. You can disable it:
+
+- **Globally**: Settings, Task Intent Widget, "Enabled" toggle off. The widget never appears in any provider's chat.
+- **Per provider**: Settings, Task Intent Widget, Per-provider, toggle Claude / Codex / Gemini / Ollama independently. Useful if you want it for Claude but find it noisy on Ollama.
+- **Per chat bubble**: click the X on a widget instance. The dismiss is sticky for that specific bubble. Other widgets in other bubbles still appear.
+
+The detection cost when disabled is zero. The regex isn't even run.
+
+## Tuning detection accuracy
+
+The widget is calibrated against a corpus of 100 example messages (30+ of which are negative examples like sarcasm, hypotheticals, or chit-chat that shouldn't trigger). The current calibration aims for precision >= 0.85 and recall >= 0.75 on that corpus.
+
+If you find the widget firing too often or too rarely on your messages, file an issue on the [desktop repo](https://github.com/tallyfy/desktop/issues) with the prompt text and what you expected. Real-world miscalibrations feed back into the test corpus.
+
+## What it looks like in each provider
+
+The widget UI is identical across providers; what changes is the detection signal:
+
+- **Claude** - both stages run; the highest accuracy. Tool-use events from Claude's MCP calls can also trigger the widget (e.g., if Claude calls the Tallyfy `create_task` MCP tool, the widget reflects what was created).
+- **Gemini** - stage 1 only in v1. Detection accuracy is lower than Claude.
+- **Codex** - stage 1 only. Plain text stream means the widget watches Codex's response chunks for patterns.
+- **Ollama** - stage 1 only. Works the same as Codex; quality depends on how clearly the local model articulates intent.
+
+## When the widget is the moat
+
+If you're evaluating Tallyfy Desktop against other AI clients, the widget is the differentiator. Plenty of apps let you chat with Claude. Almost none of them let you turn that chat into structured work in a workflow system with one click.
+
+The widget is also the answer to "why use Tallyfy Desktop instead of the web client." The web client doesn't have any AI providers at all. The desktop app does, and the widget binds them to Tallyfy.
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Overview</b>" href="/products/pro/integrations/tallyfy-desktop-ai/" > What Tallyfy Desktop is, the four AI tabs, the mandatory sign-in gate, and the Tallyfy MCP auto-injection. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Terminal Jobs</b>" href="/products/pro/integrations/tallyfy-desktop-ai/terminal-jobs/" > Track every AI run, view streamed output, cancel running jobs. The outbound side of the AI-to-Tallyfy loop. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Claude</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-claude/" > Install the Anthropic Claude CLI. Claude is the only provider that runs stage-2 LLM detection in v1. </LinkTitleCard>
+<LinkTitleCard header="<b>Integrations > MCP server</b>" href="/products/pro/integrations/mcp-server/" > Tallyfy's MCP server is auto-injected into every chat. Claude's MCP tool calls also feed the widget's detection. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/terminal-jobs.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/terminal-jobs.mdx
@@ -2,7 +2,7 @@
 about_tallyfy: true
 description: The Terminal Jobs tab is your persistent log of every AI run in Tallyfy Desktop. Each run is also a Tallyfy task, so the same history appears in your Tallyfy account. Local SQLite, tiered cancellation, and full streaming output replay.
 sidebar:
-  order: 20
+  order: 6
   label: Terminal Jobs
 title: Terminal Jobs tab
 ---

--- a/src/content/docs/pro/integrations/tallyfy-desktop-ai/terminal-jobs.mdx
+++ b/src/content/docs/pro/integrations/tallyfy-desktop-ai/terminal-jobs.mdx
@@ -1,0 +1,159 @@
+---
+about_tallyfy: true
+description: The Terminal Jobs tab is your persistent log of every AI run in Tallyfy Desktop. Each run is also a Tallyfy task, so the same history appears in your Tallyfy account. Local SQLite, tiered cancellation, and full streaming output replay.
+sidebar:
+  order: 20
+  label: Terminal Jobs
+title: Terminal Jobs tab
+---
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## What the Terminal Jobs tab is
+
+The Terminal Jobs tab is the Tallyfy Desktop view of every AI run you've ever started. Each row is one run: provider, model, prompt summary, start time, duration, status, and cost (where the provider reports it). Click any row to expand a panel that shows the full streamed output of that run.
+
+Think of it as the desktop app's process monitor for AI work. If Activity Monitor is to the OS what Terminal Jobs is to your AI history.
+
+![Terminal Jobs tab with several entries showing provider, model, duration, and status](https://screenshots.tallyfy.com/desktop-ai/terminal-jobs.png)
+
+## Every run is also a Tallyfy task
+
+The v2.0.0 invariant: every AI run, including local Ollama runs, creates a row in a system Tallyfy checklist called "AI Runs." The checklist is created automatically on your first run. The task records:
+
+- The provider (Claude, Codex, Gemini, Ollama)
+- The model name
+- A short summary of the prompt (first 80 characters)
+- The start and end timestamps
+- The cost in USD (where the provider reports it; 0 for Ollama and Codex)
+- The terminal status (success, error, cancelled)
+- A deep link back to the desktop app: `tallyfy://desktop-run/<runId>`
+
+If something fails, the task stays. It's marked with the error code so you can see what happened from any device that has access to your Tallyfy account.
+
+This is what makes Terminal Jobs and Tallyfy work in tandem:
+
+| View | Lives on | Best for |
+|---|---|---|
+| Terminal Jobs tab | Your local SQLite database | Real-time view of running jobs, full streamed output replay, cancellation |
+| AI Runs checklist in Tallyfy | Tallyfy cloud | Cross-device run history, audit log, automation triggers on AI activity |
+
+If you have Tallyfy Desktop installed on two computers, each one has its own Terminal Jobs tab (showing only that machine's runs), but the Tallyfy "AI Runs" checklist shows every run from every machine.
+
+## Reading a run row
+
+Each row shows:
+
+- **Provider icon** - Claude, Codex, Gemini, or Ollama
+- **Model** - the exact model name (e.g., `claude-sonnet-4-6`, `gemini-2.5-flash`)
+- **Prompt summary** - the first 80 characters of your prompt
+- **Started** - relative timestamp (e.g., "3 minutes ago"), with the exact UTC timestamp on hover
+- **Duration** - end minus start, in seconds or minutes
+- **Cost** - USD cost reported by the provider, or "n/a" for Ollama and Codex
+- **Status** - one of:
+  - **Running** - active right now, with a spinner
+  - **Success** - completed without error
+  - **Error** - hit an error code; expand to see the message and recovery hint
+  - **Cancelled** - you (or the system) cancelled it before completion
+
+The row also shows the run id (a short hash). Pass it to the desktop app's command palette or paste it into a Tallyfy task comment to deep-link the run.
+
+## Viewing run details
+
+Click any row to expand the detail panel. It shows:
+
+1. **Full prompt** - what you typed
+2. **Streamed output** - the assistant's response, exactly as it appeared in the chat, including any tool use blocks
+3. **Thinking blocks** (Claude only) - collapsed by default; expand to see the model's reasoning
+4. **Tool calls** - each MCP or Tallyfy tool the AI invoked, with input parameters and output
+5. **Token usage** - input tokens, output tokens, and cache stats (Claude only)
+6. **Terminal event** - the final `result` or `error` from the provider
+
+The detail panel is read-only. To re-run the same prompt, click **Open in chat**; the original chat session reappears in the corresponding provider tab with the prompt pre-filled.
+
+## Cancelling a running job
+
+Click the cancel button (X icon) on any row whose status is "Running." Tallyfy Desktop uses a tiered cancellation policy:
+
+1. **SIGINT** - sent first. The CLI gets a clean interrupt; most providers stop within a second or two.
+2. **SIGTERM** - sent after 2 seconds if SIGINT didn't take. Forces a process termination.
+3. **SIGKILL** - sent after another 5 seconds if SIGTERM didn't take. Unconditional kill.
+
+The cancelled run emits a clean `error` event with code `cancelled` and the Tallyfy task is updated with status `cancelled`. Token usage and partial output up to the cancel point are preserved.
+
+For Ollama runs (which talk to the local daemon over HTTP), cancellation propagates an `AbortSignal` through the HTTP request; the daemon stops generating tokens within a few milliseconds.
+
+## Filtering and search
+
+The Terminal Jobs tab has a search bar at the top. Type any of:
+
+- A provider name (e.g., `claude`) to filter to that provider's runs
+- A model name (e.g., `gemini-2.5-flash`)
+- A keyword from the prompt
+- A status (e.g., `error`, `cancelled`)
+- A date (e.g., `today`, `yesterday`, `2026-05-19`)
+
+Filters combine: `claude error today` shows Claude runs that failed today.
+
+There's also a quick-filter strip at the top:
+
+- **All** - default
+- **Running** - active jobs only
+- **Today** - runs started today (your local timezone)
+- **Failed** - status error or cancelled
+- **Costly** - runs over a threshold (default $0.50 USD; configurable in settings)
+
+## Local SQLite storage
+
+The Terminal Jobs data lives in a SQLite database on your machine at:
+
+- **macOS**: `~/Library/Application Support/Tallyfy/runs.db`
+- **Windows**: `%APPDATA%\Tallyfy\runs.db`
+- **Linux**: `~/.config/Tallyfy/runs.db`
+
+Why local: AI runs can contain sensitive prompts (HR conversations, contract drafts, code with API keys you accidentally pasted). Storing the raw event stream locally means the only cloud copy is the Tallyfy task metadata, which is much narrower.
+
+The database has three tables:
+
+- `runs` - one row per run, with the columns shown in the tab
+- `events` - the full AIEvent stream for each run (text chunks, tool calls, errors)
+- `tasks` - the mapping from run id to Tallyfy task id
+
+The `events` table can grow quickly if you have long chats. Tallyfy Desktop auto-prunes events older than 90 days (the `runs` and `tasks` rows stay; only the streaming detail is dropped). Pruning can be disabled in settings.
+
+## Exporting runs
+
+For compliance or audit, you can export run data:
+
+1. Click any run row to expand it
+2. Click **Export** at the bottom of the detail panel
+3. Pick **JSON** (raw events) or **Markdown** (readable transcript)
+
+The export includes everything the local database has for that run. The Tallyfy task is not included in the export (it's already in Tallyfy; query that side for the audit-trail view).
+
+## Privacy guardrails
+
+A few things Terminal Jobs does *not* do:
+
+- It doesn't send the raw streamed events to Tallyfy. Only the metadata (provider, model, prompt summary, cost, duration) makes it to the Tallyfy task.
+- It doesn't send anything to a third-party telemetry endpoint. Tallyfy Desktop's optional telemetry covers feature usage, not run content.
+- It doesn't store your Tallyfy session token in `runs.db`. The token is in the OS keychain; runs.db only stores the run id and the Tallyfy task id.
+
+## What this enables
+
+Because every AI run is a Tallyfy task, you can do things that wouldn't be possible if the runs lived only inside the desktop app:
+
+- **Trigger automations on AI activity**. Set up a Tallyfy automation: when an AI Run task is created with cost > $1, notify the team.
+- **Audit AI usage by user**. Filter the AI Runs checklist by assignee to see who's using the most AI time.
+- **Cross-device continuity**. Start a long-running Claude job on your laptop; check its status from your phone via the Tallyfy mobile app.
+- **Tie AI runs to processes**. If an AI run created a task in another Tallyfy process, you can see the chain in the task's metadata.
+
+The [Task Intent Widget](/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/) is the inbound side of this loop. Terminal Jobs is the outbound side: it's the audit trail of every run that happened.
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Overview</b>" href="/products/pro/integrations/tallyfy-desktop-ai/" > What Tallyfy Desktop is, the four AI tabs, and why every AI run becomes a Tallyfy task. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Task Intent Widget</b>" href="/products/pro/integrations/tallyfy-desktop-ai/task-intent-widget/" > The widget that turns AI chat into Tallyfy tasks, process launches, and template edits with one click. The inbound side of the AI-to-Tallyfy loop. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Claude</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-claude/" > Install the Anthropic Claude CLI and sign in with your Claude.ai subscription. Claude reports cost per run, which appears in Terminal Jobs. </LinkTitleCard>
+<LinkTitleCard header="<b>Tallyfy Desktop AI > Connect Ollama</b>" href="/products/pro/integrations/tallyfy-desktop-ai/connect-ollama/" > Install Ollama locally and run open-source models offline. Ollama runs still appear in Terminal Jobs and create Tallyfy tasks. </LinkTitleCard>
+</CardGrid>


### PR DESCRIPTION
## Summary

Adds a new section under `src/content/docs/pro/integrations/tallyfy-desktop-ai/` for the v2.0.0 AI Surface Pivot in Tallyfy Desktop. End-user docs covering the multi-tab AI surface, the per-provider connect guides, the Task Intent Widget, and the Terminal Jobs tab.

Cross-repo companion: [tallyfy/desktop#90](https://github.com/tallyfy/desktop/pull/90) (CLAUDE.md cross-link).

## Files added

7 MDX files, 10,010 words, all under `src/content/docs/pro/integrations/tallyfy-desktop-ai/`:

| File | Words | Purpose |
|---|---|---|
| `index.mdx` | 1,501 | Section landing page. Covers the seven user-visible changes in v2.0.0 (four provider tabs, Task Intent Widget, mandatory sign-in, MCP auto-injection, system AI Runs checklist, Terminal Jobs, auto-installer), the subscription-only stance, and the privacy/data-flow model. |
| `connect-claude.mdx` | 1,369 | Install + OAuth for Claude. Install Wizard with Shift-hold consent gesture (Option A), or manual `curl ... \| bash` (Option B). Troubleshooting, capability matrix. |
| `connect-codex.mdx` | 1,211 | Install + OAuth for OpenAI Codex via `npm install -g @openai/codex`. Calls out the v1 limitations (no MCP, no cost reporting, no thinking events). |
| `connect-gemini.mdx` | 1,178 | Install + OAuth for Google Gemini via `npm install -g @google/gemini-cli`. Explains the `gemini-2.5-flash` default (subscription quota friction with `gemini-3-pro-preview`). |
| `connect-ollama.mdx` | 1,428 | Local-only Ollama install (`brew install ollama` on macOS, `winget` on Windows, `curl \| sh` on Linux). Model picking guide. Privacy guarantee. |
| `terminal-jobs.mdx` | 1,490 | The Terminal Jobs tab guide. Tiered cancellation (SIGINT->SIGTERM->SIGKILL), local SQLite storage, how it pairs with the Tallyfy AI Runs checklist for cross-device history. |
| `task-intent-widget.mdx` | 1,833 | The Task Intent Widget. Three intent kinds, four widget states, two-stage detector (regex + Claude-only LLM extraction), per-intent prefill shapes. |

## Source material

Every install command and capability claim is sourced from the desktop repo:

- Install commands: `app/services/ai/install-scripts.ts`
- Provider capabilities: `docs/PROVIDER-MATRIX.md`
- Architecture model: `docs/AI-ARCHITECTURE.md`
- Intent detector: `docs/TASK-INTENT-WIDGET.md`
- Computer Use deferral: `docs/COMPUTER-USE-DEFERRED.md`

No values are guessed - the published v2.0.0 ships exactly what these docs describe.

## Compliance with docs/CLAUDE.md content rules

- Zero em-dashes (U+2014) and zero en-dashes (U+2013) - verified with grep
- Zero blacklisted words (delve, landscape, tapestry, multifaceted, pivotal, comprehensive, seamless, robust, leverage, facilitate, paramount, meticulous, underscore, moreover, furthermore, indeed, subsequently, additionally, endeavor, embark, in essence, notably, arguably, methodology, stakeholder, innovative, scalable, utilize) - verified with grep
- Contractions throughout (each article has 5+; longest has 18)
- Headings in sentence case (proper nouns and acronyms allowed)
- Frontmatter descriptions 150-350 chars, end with period
- No manual `id` or `lastUpdated` fields - the documentation-pipeline workflow auto-generates these on push

## Sidebar navigation

Each MDX file has `sidebar.order` set so the section flows logically:

- `index.mdx` (order: 1) - landing page
- `connect-claude.mdx` (order: 10), `connect-codex.mdx` (order: 11), `connect-gemini.mdx` (order: 12), `connect-ollama.mdx` (order: 13)
- `terminal-jobs.mdx` (order: 20), `task-intent-widget.mdx` (order: 21)

Starlight builds the sidebar automatically from this. No manual nav config edits needed.

## Screenshots

Image references use `https://screenshots.tallyfy.com/desktop-ai/<file>.png` per this repo's convention (R2-hosted, uploaded via `scripts/asset_management/orchestrator.py`).

**Screenshots to capture and upload before staging->main merge** (Amit handles via the orchestrator script):

| Path | Used in | Description |
|---|---|---|
| `desktop-ai/overview-screenshot.png` | `index.mdx` | Tallyfy Desktop main window with all four AI tabs visible, Claude tab active showing a streamed response |
| `desktop-ai/terminal-jobs.png` | `terminal-jobs.mdx` | Terminal Jobs tab with 6+ rows: mix of providers, mix of statuses (Running/Success/Error/Cancelled) |
| `desktop-ai/task-intent-widget.png` | `task-intent-widget.mdx` | Chat bubble with the Task Intent Widget in Collapsed state at the bottom |
| `desktop-ai/install-wizard-consent.png` | `connect-claude.mdx` | Install Wizard for Claude on the consent screen with the bash command, risks list, and Hold-Shift button |
| `desktop-ai/install-wizard-progress.png` | `connect-claude.mdx` | Install Wizard on the progress step with streamed installer output and verification line |

Until those land, Astro renders the alt text in place of the missing images - the section is publishable as-is.

## Cross-links to internal architecture docs

Each MDX file links back to the desktop repo's `docs/AI-ARCHITECTURE.md`, `docs/PROVIDER-MATRIX.md`, and `docs/COMPUTER-USE-DEFERRED.md` via `https://github.com/tallyfy/desktop/blob/main/docs/...` so end users curious about implementation can dig in.

## Test plan

- [ ] CI / Astro build green on this PR
- [ ] CF Pages preview at the staging URL renders the new section
- [ ] All in-section cross-links resolve in the preview
- [ ] Screenshot placeholder alt text reads correctly where images are missing
- [ ] After staging review, capture the 5 listed screenshots and upload via the asset management orchestrator
- [ ] Merge staging to main once the desktop repo's companion PR also lands

## Related

- Closes [tallyfy/desktop#38](https://github.com/tallyfy/desktop/issues/38)
- Companion PR: [tallyfy/desktop#90](https://github.com/tallyfy/desktop/pull/90) (CLAUDE.md cross-link)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup guides for connecting Tallyfy Desktop to Claude, Codex, Gemini, and Ollama (install-wizard and manual flows, self-verification, troubleshooting, and capability summaries)
  * Added Task Intent Widget docs covering intent types, UI states, opt-in LLM extraction, tuning, and disable options
  * Added Terminal Jobs docs covering persisted AI run history, search/filter/export, cancellation behavior, and privacy guardrails
  * Added Tallyfy Desktop AI v2 overview (MCP auto-injection, Shift-held installer behavior, subscription/access and privacy notes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions under `src/content/docs`; no application code, auth, or data-handling logic changes.
> 
> **Overview**
> Adds a new **Tallyfy Desktop AI** docs section under Pro integrations with seven MDX pages for Desktop v2.0.0’s AI surface.
> 
> The **landing page** explains the v2 pivot: four provider tabs, mandatory Tallyfy sign-in, MCP auto-injection, the **AI Runs** checklist, **Terminal Jobs**, the Shift-hold Install Wizard, subscription-only auth (no API keys), privacy/data flow, and first-launch OS warnings for unsigned builds.
> 
> **Per-provider connect guides** cover Claude, Codex, Gemini, and Ollama—Install Wizard vs manual setup, OAuth/subscription notes, verification commands, troubleshooting, and v1 capability tables (MCP, cost, attachments, etc.).
> 
> **Task Intent Widget** and **Terminal Jobs** get dedicated articles: intent types and two-stage detection, widget UI states, local SQLite history, tiered job cancellation, search/export, and how runs mirror as Tallyfy tasks.
> 
> Pages use Starlight frontmatter (`sidebar.order`), cross-links within the section and to the MCP server doc, R2 screenshot URLs (placeholders until assets upload), and links to the desktop repo architecture docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8041572071acc3c953dde5d5c701f273e4fbbbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->