### PR TITLE
Phase 3 docs: allocated-seats billing (customer help docs)

### DIFF
--- a/src/content/docs/pro/pricing/index.mdx
+++ b/src/content/docs/pro/pricing/index.mdx
@@ -1,7 +1,7 @@
 ---
 about_tallyfy: true
 description: Tallyfy offers transparent pricing with annual and monthly billing, two
-  member tiers (Full and Light), credit-based billing through Recurly, a Fair Price
+  seat types (Full and Light), seat-based billing through Recurly, a Fair Price
   Guarantee for eligible countries, and nonprofit discounts.
 id: c143f0529be9a477f30c150757761086
 lastUpdated: 2026-03-22
@@ -41,24 +41,24 @@ Only give **Full Member** licenses to people who design workflows. Everyone else
 :::
 
 :::note[Tallyfy Analytics add-on]
-*   The optional [Tallyfy Analytics](/products/pro/integrations/analytics/) add-on has separate annual fees per active user.
-*   Analytics requires an **annual** Tallyfy subscription.
-*   It applies to **every** active member in your account.
+*   The optional [Tallyfy Analytics](/products/pro/integrations/analytics/) add-on is priced per full seat, per year, and scales automatically as you add full seats.
+*   See [billing add-ons and usage credit](/products/pro/settings/billing/billing-add-ons-and-usage-credit/) for how it works.
 :::
 
 :::note[What's included for free?]
 All paid Tallyfy subscriptions include: unlimited guests, Single Sign-On (SSO), AI-powered workflow features, support consultations, and a 14-day trial. You can request a trial extension through [Tallyfy support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/). Sharing public templates is also free.
 :::
 
-### Credit-based billing
+### Seat-based billing
 
-Annual subscriptions use a credit-based billing system through Recurly. It works like a prepaid balance:
+Tallyfy bills per seat through Recurly. You commit to a number of full and light seats and pre-pay for your term:
 
-*   **Prepaid credits** - your subscription creates a credit balance that covers changes automatically
-*   **Credits used first** - adding users or upgrading consumes existing credits before charging your card
-*   **Active users only** - you're only billed for active team members
-*   **Proportional refunds** - removing a user mid-cycle refunds unused time as credits
-*   **Credit expiration** - credits expire per billing terms and aren't refundable
+*   **Committed seats** - your plan bills the full and light seats you commit to
+*   **Buy more anytime** - added seats are pro-rated for the rest of your term
+*   **True-down at renewal** - your plan adjusts to the lowest seat count you held during the period
+*   **Invoiced accounts** - manual and multi-entity accounts are billed through Xero by wire or ACH
+
+For the full model, see [how seat billing works](/products/pro/settings/billing/how-seat-billing-works/). Accounts payable teams can also pre-fund a balance under the [Terms for Credit Purchase](https://tallyfy.com/legal/terms-for-credit-purchase/).
 
 ### Fair Price Guarantee
 

--- a/src/content/docs/pro/settings/billing/billing-add-ons-and-usage-credit.mdx
+++ b/src/content/docs/pro/settings/billing/billing-add-ons-and-usage-credit.mdx
@@ -1,0 +1,60 @@
+---
+about_tallyfy: true
+description: Two kinds of add-ons sit on top of your seats. Analytics is priced per full seat per year and scales automatically. AI tokens and per-task credit are pre-paid balances you buy upfront and draw down daily as you use them.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 28
+title: Billing add-ons and usage credit
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## Two kinds of add-ons
+
+Tallyfy has two kinds of add-ons that sit on top of your seats. **Analytics** is a yearly add-on priced per full seat. **Usage credit** (AI tokens and per-task credit) is a pre-paid balance you buy upfront and draw down as you use it. You manage both from **Settings** > **Billing**.
+
+## Analytics add-on
+
+Analytics costs $20 per full seat, per year. Turn it on with a single toggle, and Tallyfy shows the computed annual amount (your full seats times $20) before you confirm. It scales automatically: add full seats mid-term and your Analytics charge grows to match, with no separate step.
+
+For multi-entity accounts, Analytics appears as a single line across all your linked workspaces on your invoice.
+
+## Pre-paid usage credit
+
+AI tokens and per-task credit work as pre-paid balances. You buy an amount upfront, and Tallyfy draws it down as you use the feature. You're never billed after the fact for usage. Your balance updates once a day, so "drawn down daily" is exactly what it sounds like.
+
+Two things to watch for:
+
+*   **Low balance** - when your credit runs low, you'll see a banner: "Your credit is running low. Top up to avoid interruption."
+*   **Out of credit** - when the balance reaches zero, the feature pauses with "You're out of credit. Top up to continue." This is a hard stop, not a warning. The feature stays blocked until you top up.
+
+:::note[Usage credit pricing]
+Pricing for AI tokens and per-task credit is being finalized. [Contact Tallyfy Support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/) for current rates.
+:::
+
+## Top up your credit
+
+<Steps>
+1. Go to **Settings** > **Billing**.
+2. Find the AI tokens or per-task credit you want to top up.
+3. Enter an amount in US Dollars.
+4. Confirm. Your balance goes up by that amount, and the feature keeps running.
+</Steps>
+
+## How you pay for add-ons
+
+How you pay depends on your billing type:
+
+*   **Card (automatic) accounts** pay for add-ons and credit top-ups instantly by card.
+*   **Invoiced and multi-entity accounts** get add-ons and credit on their Xero invoice, paid by ACH or wire transfer. [Contact Tallyfy Support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/) to arrange these.
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > How seat billing works</b>" href="/products/pro/settings/billing/how-seat-billing-works/"> Full and light seats and your committed seat pool. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Buy more seats</b>" href="/products/pro/settings/billing/how-to-buy-more-seats/"> Add full seats, and your Analytics charge scales to match. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Billing history</b>" href="/products/pro/settings/billing/understanding-your-billing-history/"> Add-on charges and top-ups show in your billing activity. </LinkTitleCard>
+<LinkTitleCard header="<b>Pro > Pricing</b>" href="/products/pro/pricing/"> Current seat and add-on pricing. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/settings/billing/how-seat-billing-works.mdx
+++ b/src/content/docs/pro/settings/billing/how-seat-billing-works.mdx
@@ -1,0 +1,62 @@
+---
+about_tallyfy: true
+description: Tallyfy bills per seat. You commit to a number of full and light seats, pre-pay for your term, and active members draw from that pool. Seats free up when members are deactivated, and your plan trues down at renewal.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 5
+title: How seat billing works
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## Seat billing in plain terms
+
+Tallyfy is billed per seat. A seat is a paid license for one person on your team. You commit to a number of seats, pre-pay for your term, and your active members draw from that pool. You can hold more seats than you're using, so new people can join without a delay.
+
+There are two seat types, plus free guests.
+
+## Full seats and light seats
+
+The two paid seat types cover different kinds of work:
+
+*   **Full seats** can create and edit templates, launch and assign work, and track, approve, and complete tasks.
+*   **Light seats** are a lower-cost license for people who only complete the tasks assigned to them.
+
+Guests from outside your organization stay free and never use a seat. They only see the specific tasks you share with them. For what each seat type costs, see the [pricing page](https://tallyfy.com/pricing/).
+
+## Your seat pool: committed and active
+
+Two numbers describe your seat pool, and Tallyfy tracks full seats and light seats separately:
+
+*   **Committed seats** are the seats you've agreed to pay for over your current term. This is the number your plan bills.
+*   **Active seats** are the seats in use right now. A seat is used when someone accepts an invite or signs in through single sign-on, and it returns to the pool when that member is deactivated.
+
+You can hold more committed seats than you've filled. The spare seats stay ready for new people. You can't lower your committed count below the number of active members, because those people are already working.
+
+## When your bill changes
+
+Your committed seats stay fixed during your term unless you change them:
+
+*   **Adding seats** happens anytime and is pro-rated for the time left in your term. See [how to buy more seats](/products/pro/settings/billing/how-to-buy-more-seats/).
+*   **Reducing seats** takes effect at your next renewal, not mid-term. At renewal, your plan trues down to the lowest seat count you held during the period.
+
+This means you're never billed more than the seats you committed to, and a temporary dip in your team doesn't lower your committed total until the term turns over.
+
+## Annual or monthly
+
+You can pay annually or monthly. Annual plans are a 12-month commitment and cost less per seat. Monthly plans commit for the current month. Free SSO and unlimited guests are included on every plan. See the [pricing page](https://tallyfy.com/pricing/) for current rates.
+
+:::note[AppSumo lifetime customers]
+Your AppSumo lifetime deal covers 3 full seats at no cost, forever, and nothing about that changes. Need more people? You can add seats anytime at standard pricing. Only the seats above your 3 free ones are billed.
+:::
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > Buy more seats</b>" href="/products/pro/settings/billing/how-to-buy-more-seats/"> Add full or light seats anytime. The cost is pro-rated for the rest of your term and shown before you confirm. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Account and member limits</b>" href="/products/pro/settings/billing/what-are-tallyfys-account-and-member-limits/"> See what full members and light members can each do, plus guest access. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Subscribe to a paid plan</b>" href="/products/pro/settings/billing/subscribing-to-a-paid-plan/"> Turn your free trial into a paid plan by choosing your seats and paying online. </LinkTitleCard>
+<LinkTitleCard header="<b>Pro > Pricing</b>" href="/products/pro/pricing/"> Tallyfy pricing with annual and monthly billing and two seat types. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/settings/billing/how-the-seat-allocator-works.mdx
+++ b/src/content/docs/pro/settings/billing/how-the-seat-allocator-works.mdx
@@ -1,0 +1,60 @@
+---
+about_tallyfy: true
+description: Multi-entity accounts run linked workspaces under one billing parent that shares a seat pool. The Seat Allocator lets a billing parent administrator distribute full and light seats across those workspaces from Settings then Billing.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 15
+title: How the Seat Allocator works
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## What the Seat Allocator is for
+
+Larger organizations can run several linked workspaces under one billing parent that shares a single seat pool. The **Seat Allocator** in **Settings** > **Billing** is where you split that shared pool of full and light seats across the linked workspaces. This page is for administrators of organizations that belong to a billing parent. If your account isn't set up this way, you won't see the Seat Allocator.
+
+To set up a multi-entity contract, [talk to our team](https://tallyfy.com/booking/).
+
+## Who can view and who can change
+
+Every admin of a linked organization can open the Seat Allocator and see how seats are split. Only a designated **billing parent administrator** can change the allocations. If you're an admin without that role, you'll see a read-only view with a note: "You're viewing in read-only mode. Only billing parent administrators can change seat allocations."
+
+## What you'll see
+
+The Seat Allocator has a header and three tabs:
+
+*   **Header** - your shared pool of full and light seats, how many are allocated versus committed, your current term dates, and whether each entity is invoiced on its own or together.
+*   **Allocations** - redistribute full and light seats across the linked organizations.
+*   **History** - an audit trail of past allocation changes.
+*   **Administrators** - the people who can change allocations.
+
+## Allocate seats across your workspaces
+
+Billing parent administrators move seats between linked organizations within the committed pool:
+
+<Steps>
+1. Open **Settings** > **Billing** > **Seat Allocator**.
+2. Go to the **Allocations** tab.
+3. Set the full and light seats for each linked organization.
+4. Save your changes.
+</Steps>
+
+Two limits keep allocations valid. You can't allocate fewer seats to an organization than it currently has active, because those people are already working. And the total you allocate can't go above the committed pool. To grow the pool itself, [buy more seats](/products/pro/settings/billing/how-to-buy-more-seats/).
+
+## Add an administrator or link a new organization
+
+Some changes are handled by Tallyfy Support to keep your billing accurate:
+
+*   **Add an administrator** - on the Administrators tab, use **Add administrator**. This opens a pre-filled email to Tallyfy Support, who completes the change. A billing parent administrator can also revoke another administrator's access, but not the last remaining one.
+*   **Request a new organization** - use **Request new organization** to open a pre-filled support email. Tallyfy Support links the new workspace to your billing parent.
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > How seat billing works</b>" href="/products/pro/settings/billing/how-seat-billing-works/"> Committed and active seats, full versus light, and renewal true-down. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Buy more seats</b>" href="/products/pro/settings/billing/how-to-buy-more-seats/"> Grow the shared pool by adding seats to your plan. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Billing history</b>" href="/products/pro/settings/billing/understanding-your-billing-history/"> Per-entity invoices and the billing activity feed. </LinkTitleCard>
+<LinkTitleCard header="<b>Support > Contact support</b>" href="/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/"> Reach the team to link a workspace or change administrators. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/settings/billing/how-to-access-and-manage-my-billing-details.mdx
+++ b/src/content/docs/pro/settings/billing/how-to-access-and-manage-my-billing-details.mdx
@@ -1,7 +1,7 @@
 ---
 about_tallyfy: true
-description: Manage your Tallyfy subscription, payment methods, credits, and invoices
-  from Settings > Billing. Only administrators can access billing, change plans, apply
+description: Manage your Tallyfy subscription, seats, payment methods, and invoices
+  from Settings > Billing. Only administrators can access billing, buy seats, apply
   coupons, or handle cancellations.
 id: 5e8b51e4ab015a41c9591445d153503d
 lastUpdated: 2026-03-22
@@ -14,7 +14,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## Access your billing details
 
-Go to **Settings** > **Billing** to manage your subscription, payment method, credits, and invoices. Only administrators can access this section.
+Go to **Settings** > **Billing** to manage your subscription, seats, payment method, and invoices. Only administrators can access this section.
 
 <Steps>
 1. Click **Settings** (bottom left).
@@ -22,7 +22,7 @@ Go to **Settings** > **Billing** to manage your subscription, payment method, cr
 
     ![Tallyfy billing settings navigation](https://screenshots.tallyfy.com/tallyfy%2Fpro%2Fdesktop-light-click-billing-settings.png)
 
-3. You'll see your current plan, payment method, credit balance, and billing history.
+3. You'll see your current plan and seats, payment method, and billing history.
 
     ![Tallyfy billing information screen](https://screenshots.tallyfy.com/tallyfy%2Fpro%2Fdesktop-light-show-billing-info.png)
 
@@ -32,11 +32,11 @@ Go to **Settings** > **Billing** to manage your subscription, payment method, cr
 
 From the **Billing** screen:
 
-*   Click **View Billing History** for past invoices and a plan summary.
+*   Click **View Billing History** for past invoices and a plan summary. See [understanding your billing history](/products/pro/settings/billing/understanding-your-billing-history/) for what the activity feed and invoice list show.
 *   Click **Edit Payment Card** to update your credit or debit card.
 
 :::note[Keep a payment card on file]
-You need a valid card saved even if you have pre-paid credits. This keeps your service running if credits run out.
+Keep a valid card saved even if you pre-pay by credit. This keeps your service running if a balance runs low.
 :::
 
 ### Change the billing contact
@@ -49,18 +49,21 @@ The user who created the organization is the default billing contact. To change 
 3.  Specify the new billing contact email address(es).
 </Steps>
 
-### Change your plan
+### Change your plan or buy seats
+
+If your trial hasn't been converted yet, you'll see a checkout to [subscribe to a paid plan](/products/pro/settings/billing/subscribing-to-a-paid-plan/). Once you're subscribed, the billing screen shows seat management.
 
 <Steps>
 1.  Go to **Settings** > **Billing**.
-2.  Click **Update Plan**.
-3.  Select your desired plan and billing cycle (annual or monthly).
-4.  Confirm and complete checkout.
+2.  To change your billing cycle (annual or monthly), open your plan settings and confirm.
+3.  To add capacity, click **Buy more seats**, pick full or light seats, and confirm the pro-rated amount.
 </Steps>
 
-### Credit system
+See [how to buy more seats](/products/pro/settings/billing/how-to-buy-more-seats/) for the full flow, including invoiced accounts.
 
-Your credit balance appears in the billing section. Credits are applied before your card is charged. See the [Billing overview](/products/pro/settings/billing/) for details on how credits work.
+### Add-ons and usage credit
+
+Analytics and pre-paid usage credit (AI tokens and per-task credit) appear in the billing section. See [billing add-ons and usage credit](/products/pro/settings/billing/billing-add-ons-and-usage-credit/) for what each one does and how to top up.
 
 ### Billing notification frequency
 
@@ -108,12 +111,9 @@ Cancellation takes effect at the end of your current billing period. You keep ac
 
 ### What happens if I miss a payment?
 
-1. Immediate email notification
-2. After 7 days: read-only mode (view and export only)
-3. After 14 days: access suspended
-4. After 30 days: Tallyfy reserves the right to delete data
+If you pay by card, a failed charge shows a banner asking you to update your card in **Settings > Billing > Edit Payment Card**. If you're billed by invoice, an invoice about 30 days overdue puts your organization into read-only mode until it's paid, after which access returns automatically.
 
-Fix this by updating your card in **Settings > Billing > Edit Payment Card** or [contact support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/).
+See [what happens if my payment fails](/products/pro/settings/billing/what-happens-if-my-payment-fails/) for the full details, or [contact support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/).
 
 ### Data retention after cancellation or deletion
 

--- a/src/content/docs/pro/settings/billing/how-to-buy-more-seats.mdx
+++ b/src/content/docs/pro/settings/billing/how-to-buy-more-seats.mdx
@@ -1,0 +1,53 @@
+---
+about_tallyfy: true
+description: Add full or light seats anytime from Settings then Billing. Choose a seat type, enter how many, and review the exact pro-rated amount for the rest of your term before you confirm. Seats activate once payment clears.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 10
+title: How to buy more seats
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## Add seats to your plan
+
+You can add seats to your plan anytime from **Settings** > **Billing**. Choose whether you're adding full or light seats, enter how many, and review the exact pro-rated cost before you confirm. Only administrators can buy seats.
+
+<Steps>
+1. Go to **Settings** > **Billing**.
+2. Click **Buy more seats**.
+3. Pick **full** or **light** seats (one type at a time) and enter a quantity.
+4. Review the pro-rated amount for the rest of your term.
+5. Confirm. The seats are added once payment succeeds.
+</Steps>
+
+## How the pro-rated cost works
+
+When you add seats mid-term, you only pay for the time left in your current term, not a full term. The exact amount is calculated for you and shown before you confirm, so there are no surprises. Your card is charged when you confirm, and the new seats become available as soon as the payment clears.
+
+:::note[Light seat pricing]
+Light seat pricing is being finalized. If light seats show as not yet priced when you try to buy them, [contact Tallyfy Support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/) and we'll help.
+:::
+
+## If your card is declined
+
+There's no automatic retry. If a charge fails, nothing is added and nothing is charged. The dialog shows an **Update payment method** option so you can fix the card and try again.
+
+## If you pay by invoice
+
+For accounts billed by invoice (manual or multi-entity billing), buying more seats adds them to your next invoice through Xero. The seats activate once that invoice is paid, rather than immediately. See [what happens if my payment fails](/products/pro/settings/billing/what-happens-if-my-payment-fails/) for how invoiced billing works.
+
+## When your seat pool is full
+
+If you try to activate, invite, or promote someone and your seat pool is full, Tallyfy shows a message like "Your full seat pool is full. Buy more seats to activate this user." Buy the seats from that prompt, and the waiting person is activated automatically once the purchase goes through. The person stays invited or disabled until a seat frees up or you buy more.
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > How seat billing works</b>" href="/products/pro/settings/billing/how-seat-billing-works/"> Committed versus active seats, and how your plan trues down at renewal. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Billing history</b>" href="/products/pro/settings/billing/understanding-your-billing-history/"> See seat purchases and invoices in your billing activity. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Seat Allocator</b>" href="/products/pro/settings/billing/how-the-seat-allocator-works/"> For multi-entity accounts, allocate a shared seat pool across linked workspaces. </LinkTitleCard>
+<LinkTitleCard header="<b>Org Settings > Member statuses</b>" href="/products/pro/settings/org-settings/understanding-member-statuses/"> How active, invited, and deactivated members relate to your seats. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/settings/billing/index.mdx
+++ b/src/content/docs/pro/settings/billing/index.mdx
@@ -1,8 +1,8 @@
 ---
 about_tallyfy: true
-description: Tallyfy uses a credit-based billing system through Recurly where you
-  only pay for active members. Pro-rated credits are returned when members are removed,
-  and failed payments progress from grace period to read-only mode to suspension.
+description: Tallyfy bills per seat through Recurly. You commit to full and light
+  seats, pre-pay for your term, and manage seats, payments, and invoices from Settings
+  then Billing. Invoiced and multi-entity accounts are billed through Xero.
 id: 4b81e84b77d857f3195c79b69fa86310
 lastUpdated: 2026-03-22
 sidebar:
@@ -14,34 +14,28 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## Billing overview
 
-Go to **Settings > Billing** to manage your subscription, payment methods, and invoices. Tallyfy uses Recurly as its billing partner with a credit-based system.
+Go to **Settings > Billing** to manage your subscription, seats, payment methods, and invoices. Tallyfy bills per seat and uses Recurly as its billing partner for card payments. Invoiced and multi-entity accounts are billed through Xero.
 
 The Billing section covers:
 
-*   **Plan overview** - current plan and usage
-*   **Payment management** - update cards and billing addresses
+*   **Plan and seats** - your committed full and light seats, and current usage
+*   **Payment management** - update cards and billing details
 *   **Invoice history** - past invoices and payment records
-*   **Credit management** - monitor and manage billing credits
+*   **Add-ons and credit** - Analytics and pre-paid usage credit
 
-See [How to access and manage billing details](/products/pro/settings/billing/how-to-access-and-manage-my-billing-details/) for step-by-step instructions.
+See [How to access and manage billing details](/products/pro/settings/billing/how-to-access-and-manage-my-billing-details/) for step-by-step instructions, or [how seat billing works](/products/pro/settings/billing/how-seat-billing-works/) for the model itself.
 
-### Credit system
+### Seat model
 
-Tallyfy billing credits work as a pre-paid balance:
+Tallyfy bills per seat. You commit to a number of full and light seats and pre-pay for your term. Your active members draw from that committed pool, and seats free up when members are deactivated. You can buy more seats anytime, with the cost pro-rated for the rest of your term, and at renewal your plan trues down to the lowest seat count you held. For the full picture, see [how seat billing works](/products/pro/settings/billing/how-seat-billing-works/).
 
-*   Credits are used before your payment card is charged
-*   You only pay for *active* members - billing starts when they accept their invite or sign in
-*   Removing a member or downgrading mid-cycle returns pro-rated credits for unused time
-*   Credits expire after 5 years and aren't refundable
-*   You can buy credits via bank transfer (contact support for details)
-
-:::note[Annual plans and credits]
-Pro-rated credits for removing individual members apply within your active billing term. However, canceling an annual subscription itself doesn't entitle you to a refund of the remaining months. The subscription runs for the full 12-month term.
+:::note[Annual plans]
+Annual plans are a 12-month commitment. Cancelling an annual plan doesn't entitle you to a refund of the remaining months. The plan runs for the full term, and you keep access until it ends.
 :::
 
-:::note[Payment card required]
-You must keep a valid payment card on file even if you have credits. This keeps your service running if credits run out.
-:::
+### Paying by credit pre-payment
+
+Accounts payable teams can pre-fund a credit balance instead of paying per charge. The balance is drawn down as seats and add-ons are billed. It's a funding method for invoiced customers and sits alongside the seat model. See the [Terms for Credit Purchase](https://tallyfy.com/legal/terms-for-credit-purchase/), and keep a valid card on file so service continues if a balance runs low.
 
 ### Billing notifications
 
@@ -49,21 +43,9 @@ By default, you'll get billing emails instantly when changes happen (like adding
 
 ### What happens if my payment fails?
 
-If Tallyfy can't process your payment:
+It depends on how you pay. If you pay by card, a failed charge shows a banner asking you to update your card, and a single failure doesn't lock your account. If you're billed by invoice, an invoice that's about 30 days overdue puts your organization into read-only mode until it's paid, after which access returns automatically.
 
-1. **Immediate notification** - billing emails alert you with instructions to update your payment method.
-
-2. **Grace period (Days 1-7)** - your account keeps working normally. Update your card in **Settings > Billing > Edit Payment Card**.
-
-3. **Read-only mode (Days 7-14)** - you can still log in and view/export all data, but can't create or launch processes.
-
-4. **Suspension (Days 14-30)** - access suspended. Contact [support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/) to resolve.
-
-5. **Data deletion (After 30 days)** - Tallyfy reserves the right to delete your data with notice.
-
-:::warning[Act quickly on payment failures]
-Update your payment information right away to avoid service disruption.
-:::
+For the full breakdown of banners, read-only mode, and how to restore access, see [what happens if my payment fails](/products/pro/settings/billing/what-happens-if-my-payment-fails/).
 
 ### After account deletion
 

--- a/src/content/docs/pro/settings/billing/subscribing-to-a-paid-plan.mdx
+++ b/src/content/docs/pro/settings/billing/subscribing-to-a-paid-plan.mdx
@@ -1,0 +1,58 @@
+---
+about_tallyfy: true
+description: When your free trial is ready to become paid, open Settings then Billing to subscribe. Choose monthly or annual, confirm your seats, and pay by card. ACH or wire transfer is handled by our team.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 8
+title: Subscribe to a paid plan
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## Turn your trial into a paid plan
+
+When your free trial is ready to become a paid plan, go to **Settings** > **Billing**. If you haven't subscribed yet, you'll see a short checkout. Only administrators can do this. Pick your billing term, confirm your seats, and pay by card to go live right away.
+
+<Steps>
+1. Go to **Settings** > **Billing**.
+2. Choose **monthly** or **annual** billing. Annual costs less per seat, and the total updates live as you change seats.
+3. Confirm your seats (see below), then enter your card details.
+4. Click **Subscribe**. Your plan starts as soon as the payment succeeds.
+</Steps>
+
+## Choose your seats
+
+Tallyfy is priced per seat, so the checkout starts you at the number of seats your current active members already use. You can't go below that count, because those people are already working in Tallyfy. You can add more seats now if you're growing, or leave it as is.
+
+You buy both seat types in the same checkout:
+
+*   **Full seats** for people who build and run processes.
+*   **Light seats** for people who only complete assigned tasks.
+
+For what each seat type costs, see the [pricing page](https://tallyfy.com/pricing/). To learn how the seat pool works after you subscribe, read [how seat billing works](/products/pro/settings/billing/how-seat-billing-works/).
+
+## Pay by card
+
+The checkout takes a credit or debit card, processed securely by Recurly. Your card is charged when you subscribe. If it's declined, nothing changes and nothing is saved, so you can try another card.
+
+Two optional extras sit in the same checkout:
+
+*   **Promo code** - enter one in the "Have a promo code?" field if you have it.
+*   **Analytics add-on** - tick the box to add Analytics. See [billing add-ons and usage credit](/products/pro/settings/billing/billing-add-ons-and-usage-credit/) for what it includes.
+
+## Prefer ACH or wire transfer?
+
+The self-serve checkout is card-only. If you'd rather pay by ACH, wire transfer, or against an invoice, our team sets that up for you. Use the **Contact support** link in the checkout, or [contact Tallyfy Support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/). Manual billing and multi-entity contracts are handled this way.
+
+After you subscribe, **Settings** > **Billing** switches to seat management, where you can [buy more seats](/products/pro/settings/billing/how-to-buy-more-seats/) and review your [billing history](/products/pro/settings/billing/understanding-your-billing-history/).
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > How seat billing works</b>" href="/products/pro/settings/billing/how-seat-billing-works/"> Full and light seats, your committed seat pool, and how billing changes at renewal. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Buy more seats</b>" href="/products/pro/settings/billing/how-to-buy-more-seats/"> Add seats after you subscribe. The cost is pro-rated for the rest of your term. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Add-ons and usage credit</b>" href="/products/pro/settings/billing/billing-add-ons-and-usage-credit/"> Analytics and pre-paid usage credit you can add to your plan. </LinkTitleCard>
+<LinkTitleCard header="<b>Pro > Pricing</b>" href="/products/pro/pricing/"> Current seat pricing for annual and monthly plans. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/settings/billing/understanding-your-billing-history.mdx
+++ b/src/content/docs/pro/settings/billing/understanding-your-billing-history.mdx
@@ -1,0 +1,53 @@
+---
+about_tallyfy: true
+description: Settings then Billing shows your billing history. A plain-English activity feed lists billing events with timestamps, and a separate list holds your past invoices, which you can download as PDF from Recurly or Xero.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 22
+title: Understanding your billing history
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## Where to find your billing history
+
+Go to **Settings** > **Billing** to see your billing history. It has two parts: an **activity feed** of billing events written in plain language, and a **list of invoices** you can download. Only administrators can see this.
+
+## The billing activity feed
+
+The activity feed is a running list of the billing events on your account. Each entry has a timestamp and a plain-English description, so you can see what changed and when. Typical entries include:
+
+*   **Seat pool resized** - your committed seats went up or down.
+*   **Purchase succeeded** - a seat purchase or add-on went through.
+*   **Invoice paid in Xero** - an invoiced payment was received.
+*   **Organization set read-only (payment overdue)** - an invoice passed its overdue limit.
+*   **Organization reactivated** - access was restored after a payment.
+
+The feed shows the events that matter to you. Behind-the-scenes sync steps aren't listed, so the feed stays readable.
+
+## Your invoices
+
+Below the activity feed is a list of your past invoices, each with a status such as paid, pending, overdue, or void. You can download any invoice as a PDF:
+
+<Steps>
+1. Go to **Settings** > **Billing**.
+2. Find the invoice in your billing history.
+3. Click to download the PDF.
+</Steps>
+
+If you pay by card, your invoices come from Recurly, our billing provider. If you're billed by invoice, they come from Xero. The download link is valid for a few minutes, so if it expires, just click again. To update the card itself, you'll see a secure Recurly screen.
+
+## If your history looks empty or won't load
+
+A new account with no billing activity shows "No billing history yet" until your first purchase or invoice. If a filter hides every row, clear it to bring the list back. And if the page can't load your details, you'll see a short error with a **Retry** button. None of these mean anything is wrong with your account.
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > Manage billing</b>" href="/products/pro/settings/billing/how-to-access-and-manage-my-billing-details/"> Update your payment card, change your plan, and view history. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > If your payment fails</b>" href="/products/pro/settings/billing/what-happens-if-my-payment-fails/"> What overdue and read-only states mean, and how to restore access. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Add-ons and usage credit</b>" href="/products/pro/settings/billing/billing-add-ons-and-usage-credit/"> Charges for Analytics and pre-paid usage credit also appear here. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > How seat billing works</b>" href="/products/pro/settings/billing/how-seat-billing-works/"> Understand the seat changes you'll see in the activity feed. </LinkTitleCard>
+</CardGrid>

--- a/src/content/docs/pro/settings/billing/what-are-tallyfys-account-and-member-limits.mdx
+++ b/src/content/docs/pro/settings/billing/what-are-tallyfys-account-and-member-limits.mdx
@@ -17,7 +17,7 @@ Tallyfy has two [member roles](/products/pro/documenting/members/) with differen
 *   **Full Members** - Can access all features, including creating and editing [templates](/products/pro/documenting/templates/). Includes Admin and Standard roles.
 *   **Light Members** - Can only complete assigned [tasks](/products/pro/tracking-and-tasks/tasks/) and participate in launched processes. They **can't** create or edit templates.
 
-An optional Data Feed add-on for [Tallyfy Analytics](/products/pro/integrations/analytics/) is also available.
+An optional Data Feed add-on for [Tallyfy Analytics](/products/pro/integrations/analytics/) is also available. Each Full or Light member uses a paid seat. For how seats are billed, see [how seat billing works](/products/pro/settings/billing/how-seat-billing-works/).
 
 ### Member role capabilities
 

--- a/src/content/docs/pro/settings/billing/what-happens-if-my-payment-fails.mdx
+++ b/src/content/docs/pro/settings/billing/what-happens-if-my-payment-fails.mdx
@@ -1,0 +1,51 @@
+---
+about_tallyfy: true
+description: What happens depends on how you pay. Card accounts see a banner asking you to update your card. Invoiced accounts that go about 30 days overdue are placed in read-only mode until the invoice is paid, then access returns automatically.
+id: 0000000000000000000000000000000000
+lastUpdated: 2026-06-03
+sidebar:
+  order: 30
+title: What happens if my payment fails
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## It depends on how you pay
+
+What happens after a failed payment depends on your billing type. Card accounts get a banner asking them to update their card. Invoiced accounts that go about 30 days overdue are placed in read-only mode until the invoice is paid. Either way, your data is safe, and access comes back as soon as payment goes through.
+
+## If you pay by card
+
+When a card charge fails, you'll see a banner in **Settings** > **Billing** that says your payment failed and asks you to update your payment method. Update the card on file and you're back to normal. A single failed charge doesn't lock your account on its own, so there's no rush beyond keeping a valid card on file.
+
+## If you pay by invoice
+
+Invoiced accounts are billed through Xero, usually on Net 15 terms. Tallyfy doesn't send payment reminders, so watch your invoices. As an invoice passes its due date, you'll see banners change:
+
+*   **Overdue (under 30 days)** - an amber banner: "Payment overdue. Please see billing or file a support issue to avoid service disruption."
+*   **Read-only (about 30 days overdue)** - a red banner: "This organization is read-only due to an overdue payment. Settle the invoice in Xero to restore access."
+
+## What read-only mode means
+
+In read-only mode, people can still sign in, view processes, download reports, and export data. They can't create templates, launch processes, complete tasks, edit, or invite people. If someone tries a blocked action, they'll see a short message explaining the account is read-only until the payment is settled.
+
+## How to restore access
+
+Restoring access is straightforward:
+
+*   **Invoiced accounts** - pay the overdue invoice through Xero. Tallyfy lifts read-only mode automatically on the next daily sync, usually within about a day. If you need it sooner, [contact Tallyfy Support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/) and we can sync your billing right away.
+*   **Card accounts** - update the card on file in **Settings** > **Billing**.
+
+## Why is my account read-only?
+
+The usual reason is an invoice that's about 30 days past due. Settle that invoice (or update your card, if you pay by card), and full access returns automatically once the payment is picked up. Continued non-payment beyond this point may lead to the further consequences described in our [Customer Terms](https://tallyfy.com/legal/).
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Billing > Manage billing</b>" href="/products/pro/settings/billing/how-to-access-and-manage-my-billing-details/"> Update your payment card and review your plan. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Billing history</b>" href="/products/pro/settings/billing/understanding-your-billing-history/"> Find your invoices and download them as PDF. </LinkTitleCard>
+<LinkTitleCard header="<b>Billing > Buy more seats</b>" href="/products/pro/settings/billing/how-to-buy-more-seats/"> A full seat pool is a separate state from an overdue payment. </LinkTitleCard>
+<LinkTitleCard header="<b>Support > Contact support</b>" href="/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/"> Reach the team to sync your billing or ask a question. </LinkTitleCard>
+</CardGrid>


### PR DESCRIPTION
## What this is

Customer-facing help docs for the new **allocated-seats billing model** (humming-dragon Phase 3). Sibling of `tallyfy/website-astro` #101 (pricing + legal). Targeted to be ready ahead of the GA cutover so docs match the new billing UI when customers see it.

Plan: `~/.claude/plans/working-directory-users-amitk-github-web-swift-wren.md`
Parent plan: `~/.claude/plans/just-had-a-call-humming-dragon.md`

## New pages (`pro/settings/billing/`)

- **how-seat-billing-works** - full vs light seats, the per-org seat pool (committed vs active), renewal true-down, AppSumo lifetime note.
- **subscribing-to-a-paid-plan** - self-serve trial to paid checkout (term, seat minimum, card, promo, Analytics, ACH/wire via support).
- **how-to-buy-more-seats** - pro-rated buy-more, declined-card handling, invoiced path, seat-pool-full to activate.
- **how-the-seat-allocator-works** - multi-entity billing parent, view vs change, allocate across linked orgs, add-admin / link-org via support.
- **understanding-your-billing-history** - the billing activity feed + invoice list/PDF, empty/error states.
- **billing-add-ons-and-usage-credit** - Analytics per full seat; AI tokens + per-task pre-paid credit drawn down daily, top-up, out-of-credit hard stop.
- **what-happens-if-my-payment-fails** - card banner vs Xero 30-day-overdue read-only, what read-only blocks, automatic restoration.

## Updated pages

- **billing/index**, **manage-billing**, **member-limits**: reframed the old credit / per-active-member model to the seat model; **corrected the payment-failure timeline** (the old 7/14/30-day grace/suspend/delete steps did not match the shipping behavior).
- **pro/pricing/index**: seat-based billing; Analytics shown per full seat.

## Accuracy notes

- Light-seat dollar figures are not hardcoded (api-v2 #9183 not locked) - docs link to the pricing page.
- AI-token / per-task unit prices are **not** stated (INACTIVE pending product pricing) - shown as "pricing being finalized, contact us."
- No new screenshots invented - new-UI screenshots are a post-cutover asset pass.

## Flag for reviewers (Analytics scope mismatch)

The shipping backend (api-v2 Session 12) bills **Analytics per full seat**; the live website pricing page currently applies the Data Feed add-on to **all seats, annual-only**. These docs follow the backend (per full seat). The website pricing page's Analytics scope should be reconciled separately - left unchanged here per the operator decision to keep the pricing add-on as-is.

## Pipeline

New files use the `0000...` id placeholder + `about_tallyfy: true`; the staging pipeline assigns real ids, descriptions, and Related-articles on merge. All internal links resolve; char/blacklist scans clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated billing documentation to reflect seat-based billing model instead of credit-based.
  * Added new guides for managing seats, purchasing additional seats, and understanding billing history.
  * Added new page explaining payment failure outcomes and recovery steps.
  * Added Seat Allocator feature documentation for multi-entity accounts.
  * Updated pricing and subscription documentation with revised terminology and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->