### PR TITLE
chore: relativize hardcoded path in .cursor Cursor rule

### DIFF
--- a/.cursor/rules/tallyfy-documentation.mdc
+++ b/.cursor/rules/tallyfy-documentation.mdc
@@ -9,7 +9,7 @@ alwaysApply: true
 
 **ALL AI content operations MUST incorporate the comprehensive humanizing guidelines from `../humanizing-rules.md`**. These rules ensure content appears natural, human-written, and undetectable as AI-generated.
 
-**Before any AI content work**: Review and apply the humanizing rules found in `/Users/amit/Documents/GitHub/documentation/humanizing-rules.md`
+**Before any AI content work**: Review and apply the humanizing rules found in `../humanizing-rules.md`
 
 **Required in EVERY AI prompt**: Include humanizing guidelines for conversational tone, varied sentence rhythm, specific examples, answer-first structure, and elimination of AI-typical phrases.
 


### PR DESCRIPTION
## What

Relativize the single hardcoded laptop-absolute path in `.cursor/rules/tallyfy-documentation.mdc` (a Cursor IDE rule with `alwaysApply: true`).

## Why

Line 12 hardcoded `/Users/amit/Documents/GitHub/documentation/humanizing-rules.md`, while the **same file references the same target relatively** (`../humanizing-rules.md`) in six other places (lines 10, 127, 130, 143, 160, 169). On any machine with a different GitHub root (e.g. desktop `~/GitHub`) the absolute path is wrong. Fix: match the file's own convention.

## Scope / risk

- **Hidden editor-config only.** `.cursor/` is **not** a `documentation-pipeline.yml` trigger path (triggers are `src/content/docs/**`, scripts, workflow yml), so this does **not** build, sync to support-docs, or deploy. Zero production impact.
- 1-line change; no content touched (complies with the repo separation rules).

## Note for the reviewer (not blocking)

This file appears **superseded**: the `staging` branch replaced it with `.cursor/rules/00-source-of-truth.mdc` (a stub that points Cursor at `CLAUDE.md`), and `tallyfy-documentation.mdc` exists only on `main`. You may prefer to **delete** it on `main` rather than keep it — flagging for your call. This PR only makes the existing file machine-portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Cursor IDE config change with no production or documentation pipeline impact.
> 
> **Overview**
> Replaces the **only** machine-specific absolute path in `.cursor/rules/tallyfy-documentation.mdc` with the same relative reference (`../humanizing-rules.md`) already used elsewhere in that Cursor rule file.
> 
> The “Before any AI content work” line no longer points at `/Users/amit/...`; editors and agents on other clones get a portable link to the humanizing rules. **No** doc content, build, or deploy paths are touched—`.cursor/` config only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b0e6c4103aa9300da170aae446dd96a1bb6e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->