### PR TITLE
docs(mcp-server): sync tool count 107 → 108 across integration pages

### DIFF
--- a/src/content/docs/pro/integrations/mcp-server/claude-anthropic/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/claude-anthropic/index.mdx
@@ -68,7 +68,7 @@ Yes. You sign in with your own Tallyfy account to authorize the connection, and 
 
 *(Skip this unless you're setting up the technical side.)*
 
-Tallyfy's MCP server is hosted at `https://mcp.tallyfy.com/` (note the trailing slash, no `/mcp/` suffix) and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`. The server speaks the standard streamable-http transport, authenticates via OAuth 2.1 with Dynamic Client Registration, and exposes the same 107 tools to all Claude clients (Desktop, claude.ai connectors, Claude Code). Access tokens carry the canonical `mcp_resource` claim so the server can bind the token to the resource it was issued for.
+Tallyfy's MCP server is hosted at `https://mcp.tallyfy.com/` (note the trailing slash, no `/mcp/` suffix) and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`. The server speaks the standard streamable-http transport, authenticates via OAuth 2.1 with Dynamic Client Registration, and exposes the same 108 tools to all Claude clients (Desktop, claude.ai connectors, Claude Code). Access tokens carry the canonical `mcp_resource` claim so the server can bind the token to the resource it was issued for.
 
 Claude Desktop was the first AI assistant to offer native MCP integration. The Anthropic family that supports remote MCP today includes Claude Opus, Sonnet, and Haiku models on Pro, Max, Team, and Enterprise plans, plus Claude Code in VS Code, JetBrains, and GitHub Actions. The remote setup uses OAuth, with no local installation required.
 

--- a/src/content/docs/pro/integrations/mcp-server/google-gemini/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/google-gemini/index.mdx
@@ -60,7 +60,7 @@ Tallyfy publishes two endpoints for Gemini, and they behave identically:
 - **Primary:** `https://mcp.tallyfy.com/` (hosted on DigitalOcean).
 - **Google Cloud Run mirror:** `https://mcp-gcp.tallyfy.com/` (the Tier-1 choice for Gemini Enterprise).
 
-Both expose the same 107 tools and share the same OAuth backend, so your access tokens work on either one. The server is listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`.
+Both expose the same 108 tools and share the same OAuth backend, so your access tokens work on either one. The server is listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`.
 
 The Cloud Run mirror is operationally identical to the primary endpoint but runs on Google Cloud Run. For Gemini Enterprise that means lower-latency egress, easier VPC Service Controls and Cloud Logging integration, and an origin that lives inside Google's compliance perimeter. The deploy pipeline (Cloud Build, then Artifact Registry, then Cloud Run) is fully operational, and every push to the MCP server repo deploys to both endpoints in parallel. Pick whichever endpoint your AI surface prefers - the data and behavior are the same.
 
@@ -121,7 +121,7 @@ The Cloud Run mirror is operationally identical to the primary endpoint but runs
    /mcp list
    ```
 
-   You'll see `tallyfy` listed with 107 tools.
+   You'll see `tallyfy` listed with 108 tools.
 
 5. **First use authorizes you**
 

--- a/src/content/docs/pro/integrations/mcp-server/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/index.mdx
@@ -275,7 +275,7 @@ Public endpoints:
 - `https://mcp.tallyfy.com/health` - health check
 - `https://mcp.tallyfy.com/privacy` - MCP-specific privacy summary
 
-Both endpoints share the same OAuth backend, the same 107 tools, and the same Tallyfy organization data. Pick `mcp.tallyfy.com` by default; use `mcp-gcp.tallyfy.com` when your AI platform (Gemini Enterprise in particular) prefers a Google Cloud-hosted origin.
+Both endpoints share the same OAuth backend, the same 108 tools, and the same Tallyfy organization data. Pick `mcp.tallyfy.com` by default; use `mcp-gcp.tallyfy.com` when your AI platform (Gemini Enterprise in particular) prefers a Google Cloud-hosted origin.
 
 The server is open source under Apache 2.0, so you're free to review exactly what every tool does, audit the OAuth flow, or run your own instance. The code lives at [github.com/tallyfy/mcp-public](https://github.com/tallyfy/mcp-public)<a href="https://github.com/tallyfy/mcp-public" rel="nofollow noopener noreferrer" target="_blank"><sup>[1]</sup></a>.
 

--- a/src/content/docs/pro/integrations/mcp-server/microsoft-copilot-studio/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/microsoft-copilot-studio/index.mdx
@@ -52,7 +52,7 @@ Yes. It runs on Microsoft's own security. You sign in with your normal Microsoft
 
 ### Server endpoint and support status
 
-The MCP server is hosted at `https://mcp.tallyfy.com/` and exposes 107 tools across 12 categories. It's listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`. Copilot Studio connects via streamable HTTP with OAuth 2.1.
+The MCP server is hosted at `https://mcp.tallyfy.com/` and exposes 108 tools across 12 categories. It's listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`. Copilot Studio connects via streamable HTTP with OAuth 2.1.
 
 Tallyfy is already a Microsoft Verified Publisher with a [Power Automate connector](https://learn.microsoft.com/en-us/connectors/tallyfy/) that's been live for years, so the MCP path is the natural next step for AI-driven workflow ops on the Microsoft stack. Direct MCP support inside Copilot Studio (skipping the custom-connector wrapper) is under active investigation with Microsoft.
 
@@ -82,7 +82,7 @@ The server uses OAuth 2.1 with PKCE for authentication. Discovery starts at `/.w
 
 1. **Connect to Tallyfy's MCP server**
 
-   Tallyfy provides a hosted MCP server at `https://mcp.tallyfy.com` that exposes 107 tools across 12 categories for managing tasks, processes, templates, users, form fields, kickoff fields, automation, and more. You don't need to build your own MCP server - instead, you'll create a connector that points to Tallyfy's existing server.
+   Tallyfy provides a hosted MCP server at `https://mcp.tallyfy.com` that exposes 108 tools across 12 categories for managing tasks, processes, templates, users, form fields, kickoff fields, automation, and more. You don't need to build your own MCP server - instead, you'll create a connector that points to Tallyfy's existing server.
 
    The server uses OAuth 2.1 with PKCE for authentication. Discovery starts at `/.well-known/oauth-authorization-server` (per RFC 8414), and scopes use dot notation like `mcp.tasks.read`, `mcp.processes.write`, etc.
 

--- a/src/content/docs/pro/integrations/mcp-server/openai-chatgpt/index.mdx
+++ b/src/content/docs/pro/integrations/mcp-server/openai-chatgpt/index.mdx
@@ -55,7 +55,7 @@ Yes. You sign in with your own Tallyfy account to authorize the connection and c
 
 ### Server endpoint and support status
 
-The MCP server is hosted at `https://mcp.tallyfy.com/` and exposes 107 tools. ChatGPT supports it through Custom Connectors (Team, Enterprise, Education plans) and through ChatGPT Apps (when you've installed it from the apps directory). The server is also published on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`. A verification endpoint at `https://mcp.tallyfy.com/.well-known/openai-apps-challenge` confirms ownership for OpenAI's Apps directory; Tallyfy's directory listing is in progress with OpenAI.
+The MCP server is hosted at `https://mcp.tallyfy.com/` and exposes 108 tools. ChatGPT supports it through Custom Connectors (Team, Enterprise, Education plans) and through ChatGPT Apps (when you've installed it from the apps directory). The server is also published on the [Official MCP Registry](https://registry.modelcontextprotocol.io/?q=tallyfy) as `com.tallyfy/mcp-server`. A verification endpoint at `https://mcp.tallyfy.com/.well-known/openai-apps-challenge` confirms ownership for OpenAI's Apps directory; Tallyfy's directory listing is in progress with OpenAI.
 
 - **Availability** - Team, Enterprise, and Education plans support custom MCP server connections via Developer Mode. Plus and Pro plans get pre-built connectors and installed apps from the directory.
 - **Access method** - Developer Mode (custom connector) and ChatGPT Apps (from the directory)


### PR DESCRIPTION
## Why
The MCP server exposes **108** tools, but 5 customer-facing integration pages still said "107 tools" (stale since #549 `validate_template_mapping` took it 107→108). Verified: `rg -c '@mcp\.tool\(' server/tools/*.py` = 108 (incl. always-registered `tallyfy_api_call`), and the live claude.ai connector shows 108.

## What
Surgical `107 tools` → `108 tools` on: `index`, `openai-chatgpt`, `google-gemini`, `microsoft-copilot-studio`, `claude-anthropic`. Body text only — Related articles and frontmatter untouched (verified clean diff: 7+/7−).

Companion to the mcp-server PR (tallyfy/mcp#560) which syncs the server-side surfaces. Merge to `main` to push to production (`tallyfy.com/products/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording sync with no runtime, auth, or API behavior changes.
> 
> **Overview**
> Updates customer-facing MCP integration docs so they state **108 tools** instead of the outdated **107**, matching the live server after the extra tool landed in the companion mcp-server release.
> 
> The change is a straight text swap on five pages: the main MCP hub (`index`), plus Claude, ChatGPT, Gemini, and Copilot Studio guides. Mentions in developer sections and Gemini’s `/mcp list` verification step are included; no frontmatter, related links, or other copy changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aff48c4edb135b5c24f915dd0c729e36b754b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->