### PR TITLE
docs(a11y): stop documenting + using D2 connection animation (#85 follow-up)

### DIFF
--- a/D2-DIAGRAMS.md
+++ b/D2-DIAGRAMS.md
@@ -671,49 +671,24 @@ Include these details:
 - User roles and permissions
 - Hyperlinks to related documentation
 
-### Animated Arrows in D2 Diagrams
+### Do not animate D2 connections (accessibility)
 
-**Two Types of Animations Available:**
+**Connection animation is banned for accessibility reasons.** Do NOT use `style.animated: true`.
 
-1. **Multi-Board Animations** (Transitions between diagram states)
-   - Configured via `animateInterval` in astro.config.mjs
-   - Currently set to 1000ms in /support-docs
-   - Used for showing progressive changes or steps
-   - Requires multiple boards/states in the diagram
+D2 renders animated connections as an infinite "marching ants" loop (`animation: dashdraw ... infinite`). Our diagrams are embedded as isolated `<img>` SVGs, so the page cannot pause or stop that motion - and a reader's `prefers-reduced-motion` setting can't reach inside the image. That auto-playing, never-ending motion fails WCAG 2.2.2 (Pause, Stop, Hide).
 
-2. **Animated Connections** ("Marching Ants" effect)
-   - Creates moving dashed lines on arrows to show flow direction
-   - Requires `style.animated: true` on individual connections
-   - Works with both normal and sketch modes
-   - Best for showing data flow, critical paths, or active connections
+To keep diagrams accessible:
 
-**How to Add Animated Arrows:**
-```d2
-# Static arrow (default)
-Client -> API: Request
+- **Never add `style.animated: true`** to a connection. If you do, the `remarkD2NoAnimate` build plugin (in /support-docs) strips it at build time, so it has no effect anyway - it just leaves confusing dead markup. (Issue #85.)
+- Use a plain connection. The arrowhead already shows direction:
+  ```d2
+  Client -> API: Request
+  database -> api: data flow
+  api -> frontend: JSON response
+  ```
+- To emphasize a critical path, use a thicker or colored stroke (`style.stroke-width`, `style.stroke`), a label on the edge, or `direction:` - not motion.
 
-# Animated arrow (marching ants effect)
-Client -> API: Request {
-  style.animated: true
-}
-
-# Multiple animated connections
-database -> api: data flow {
-  style.animated: true
-}
-api -> frontend: JSON response {
-  style.animated: true
-}
-```
-
-**When to Use Animated Arrows:**
-- **Sparingly** - Too many animations can be distracting
-- **Critical Flows** - Highlight the most important data paths
-- **API Documentation** - Show request/response flow direction
-- **Process Workflows** - Indicate the active path through a process
-- **Event Propagation** - Visualize how events flow through the system
-
-**Current Status:** Animated arrows are properly configured but not currently used in diagrams. Consider selectively adding them to enhance understanding of flow direction.
+The same applies to `animateInterval` (multi-board transition cycling): it is deliberately not set in /support-docs, because it would auto-cycle forever with no stop control.
 
 ### Golden Nuggets for Specific Diagram Types
 

--- a/src/content/docs/pro/documenting/documents/how-can-i-automate-document-signing-with-tallyfy.mdx
+++ b/src/content/docs/pro/documenting/documents/how-can-i-automate-document-signing-with-tallyfy.mdx
@@ -91,12 +91,10 @@ User -> Tallyfy: "1. Complete task" {
 
 Tallyfy -> Webhook: "2. Trigger webhook" {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 Webhook -> Middleware: "3. Send data" {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 Middleware -> DocuSign: "4. Create envelope" {

--- a/src/content/docs/pro/documenting/templates/master-templates-vs-processes.mdx
+++ b/src/content/docs/pro/documenting/templates/master-templates-vs-processes.mdx
@@ -94,7 +94,6 @@ Process3 -> Feedback: Feedback {
 }
 Feedback -> Template: Update template {
   style.stroke: "#225930"
-  style.animated: true
 }
 ```
 

--- a/src/content/docs/pro/integrations/analytics/powerbi/how-to-analyze-tallyfy-workflows-with-power-bi.mdx
+++ b/src/content/docs/pro/integrations/analytics/powerbi/how-to-analyze-tallyfy-workflows-with-power-bi.mdx
@@ -57,12 +57,10 @@ Start -> ODBC {
 
 ODBC -> Athena {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 Athena -> Data {
   style.stroke: "#225930"
-  style.animated: true
 }
 ```
 

--- a/src/content/docs/pro/integrations/computer-ai-agents/vendors/manus.mdx
+++ b/src/content/docs/pro/integrations/computer-ai-agents/vendors/manus.mdx
@@ -121,7 +121,6 @@ T -> W {
 
 W -> M {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 M -> P {
@@ -171,7 +170,6 @@ S -> O {
 
 O -> U {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 U -> N {

--- a/src/content/docs/pro/integrations/extract-tasks-from-meetings.mdx
+++ b/src/content/docs/pro/integrations/extract-tasks-from-meetings.mdx
@@ -135,11 +135,9 @@ Track: Active Task {
 # Main Flow
 Start -> Transcribe {
   style.stroke: "#225930"
-  style.animated: true
 }
 Transcribe -> Extract {
   style.stroke: "#225930"
-  style.animated: true
 }
 Extract -> Draft {
   style.stroke: "#225930"

--- a/src/content/docs/pro/integrations/middleware/integrate-into-crm.mdx
+++ b/src/content/docs/pro/integrations/middleware/integrate-into-crm.mdx
@@ -139,7 +139,6 @@ User -> CRM: Click magic link {
 }
 CRM -> Tallyfy: Launch with data {
   style.stroke: "#225930"
-  style.animated: true
 }
 Tallyfy -> Tallyfy: Create process {
   style.stroke: "#225930"
@@ -154,14 +153,12 @@ User -> Tallyfy: Complete task {
 }
 Tallyfy -> Middleware: Send webhook {
   style.stroke: "#225930"
-  style.animated: true
 }
 Middleware -> Middleware: Map fields {
   style.stroke: "#225930"
 }
 Middleware -> CRM: Update record {
   style.stroke: "#225930"
-  style.animated: true
 }
 CRM -> Middleware: Confirm {
   style.stroke: "#225930"

--- a/src/content/docs/pro/integrations/middleware/n8n/common-n8n-workflow-examples.mdx
+++ b/src/content/docs/pro/integrations/middleware/n8n/common-n8n-workflow-examples.mdx
@@ -107,13 +107,10 @@ Extract: "Extract Form Data"
 Check -> Skip: "No"
 Skip: "Skip Processing"
 Extract -> CRM: "Update CRM" {
-  style.animated: true
 }
 Extract -> Sheets: "Update Google Sheets" {
-  style.animated: true
 }
 Extract -> Email: "Send Email" {
-  style.animated: true
 }
 CRM -> Success: "Success Log"
 Sheets -> Success

--- a/src/content/docs/pro/integrations/middleware/n8n/connecting-n8n-to-tallyfy.mdx
+++ b/src/content/docs/pro/integrations/middleware/n8n/connecting-n8n-to-tallyfy.mdx
@@ -287,7 +287,6 @@ T -> T: "Skip webhook"
 Q -> W: 4. Process webhook
 
 W -> n8n: "5. POST to webhook_url" {
-  style.animated: true
 }
 # Timeout: 30 seconds
 n8n -> W: "6. Success response (2xx)"

--- a/src/content/docs/pro/integrations/middleware/power-automate/creating-your-first-flow-in-power-automate.mdx
+++ b/src/content/docs/pro/integrations/middleware/power-automate/creating-your-first-flow-in-power-automate.mdx
@@ -81,7 +81,6 @@ O -> O: 2. Filter subject {
 
 O -> PA: 3. Trigger flow {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 PA -> PA: 4. Extract data {
@@ -94,7 +93,6 @@ PA -> PA: 5. Format JSON {
 
 PA -> T: 6. API request {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 T -> T: 7. Validate {
@@ -111,7 +109,6 @@ TP -> T: 9. Task ID {
 
 T -> PA: 10. Response {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 PA -> PA: 11. Log success {

--- a/src/content/docs/pro/integrations/webhooks/how-to-set-up-webhooks-in-tallyfy.mdx
+++ b/src/content/docs/pro/integrations/webhooks/how-to-set-up-webhooks-in-tallyfy.mdx
@@ -106,7 +106,6 @@ Failure_Handler: Error Logged {
 Complete_Step -> Tallyfy: Trigger event {
   style.stroke: "#225930"
   style.stroke-width: 2
-  style.animated: true
 }
 
 Tallyfy -> Webhook_Type: Check type {
@@ -129,7 +128,6 @@ Event_Queue -> Webhook_Handler: Process webhook {
 Webhook_Handler -> External_System: POST JSON data {
   style.stroke: "#225930"
   style.stroke-width: 3
-  style.animated: true
 }
 
 # Success Path

--- a/src/content/docs/pro/launching/triggers/index.mdx
+++ b/src/content/docs/pro/launching/triggers/index.mdx
@@ -98,12 +98,10 @@ Manual Triggers.Manual -> Process: Launch {
 }
 Manual Triggers.Form -> Process: Launch with data {
   style.stroke: "#225930"
-  style.animated: true
 }
 
 Automated Triggers.API -> Process: Launch with payload {
   style.stroke: "#225930"
-  style.animated: true
 }
 Automated Triggers.Email -> Process: Parse and launch {
   style.stroke: "#225930"
@@ -116,7 +114,6 @@ Automated Triggers.Task -> Process: Cascade launch {
 }
 Automated Triggers.Magic -> Process: Launch via link {
   style.stroke: "#225930"
-  style.animated: true
 }
 ```
 

--- a/src/content/docs/pro/launching/triggers/via-middleware.mdx
+++ b/src/content/docs/pro/launching/triggers/via-middleware.mdx
@@ -70,7 +70,6 @@ Tallyfy: Tallyfy Platform {
 External_App -> Middleware: 1. Event triggers\n(new record, form submit) {
   style.stroke: "#225930"
   style.stroke-width: 2
-  style.animated: true
 }
 
 Middleware -> Middleware: 2. Map data fields\nto Tallyfy format {
@@ -80,7 +79,6 @@ Middleware -> Middleware: 2. Map data fields\nto Tallyfy format {
 Middleware -> Tallyfy: 3. Launch process\nwith mapped data {
   style.stroke: "#225930"
   style.stroke-width: 3
-  style.animated: true
 }
 
 Tallyfy -> Tallyfy: 4. Create process\ninstance {


### PR DESCRIPTION
Follow-up to the #85 fix (support-docs#180). Removes the D2 connection-animation anti-pattern from both the author guide and existing diagrams (WCAG 2.2.2).

- **D2-DIAGRAMS.md** (authoritative D2 guide): replaced the "Animated Arrows" section that taught `style.animated: true` with an accessibility note (use static connectors; arrowheads convey direction).
- **26 `style.animated: true` removed** across 12 diagrams. Already stripped at build by the `remarkD2NoAnimate` plugin, so **zero rendered change** - just removes dead markup. Every affected d2 fence re-rendered via the d2 CLI (valid SVG, 0 dashdraw). Auto-generated Related-articles sections untouched.

Closes #85 follow-up. Relates to #85.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and D2 source-only edits with no runtime or build-behavior change beyond aligning author guidance with existing accessibility enforcement.
> 
> **Overview**
> **Author guide (`D2-DIAGRAMS.md`)** no longer teaches `style.animated: true` or multi-board `animateInterval`. It now documents why connection animation is banned (infinite dashdraw in embedded SVG `<img>`s can't respect `prefers-reduced-motion`), points authors to static arrows and stroke/label emphasis instead, and notes the `remarkD2NoAnimate` build stripper.
> 
> **12 integration/launching doc diagrams** across 12 MDX files had **`style.animated: true` removed** from edges (26 occurrences total). Those flags were already stripped at build time, so **rendered output is unchanged**—this only removes misleading source markup aligned with issue #85.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f59b9e4632c9d1642103980e85c15c701857f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->