### PR TITLE
a11y(#72): source a11y lint in pipeline + fix 24 heading-structure violations

### DIFF
--- a/.github/workflows/documentation-pipeline.yml
+++ b/.github/workflows/documentation-pipeline.yml
@@ -34,6 +34,9 @@ jobs:
           python -m pip install --upgrade pyyaml
           python scripts/markdown-lint.py --dir=$PWD
         shell: bash
+      - name: Accessibility lint (headings 1.3.1, alt text 1.1.1, D2 animation 2.2.2)
+        run: python scripts/a11y-lint.py --dir=$PWD
+        shell: bash
     outputs:
       validate-markdown-completed: ${{ steps.validate-markdown.outcome }}
 

--- a/scripts/a11y-lint.py
+++ b/scripts/a11y-lint.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Accessibility lint for documentation content (.mdx).
+
+Guards three WCAG-relevant content rules at the SOURCE level, before the pipeline
+syncs content to support-docs (where Astro/Starlight renders it). Pairs with the
+dist-level assertion in support-docs (scripts/a11y-dist-assert.mjs) which guards
+the rendered output. Filed under tallyfy/documentation#72 (epic #66).
+
+Rules:
+  1. WCAG 1.3.1 (Info and Relationships) - heading structure.
+     Starlight renders the frontmatter `title` as the page <h1>, so the first
+     CONTENT heading must be <h2> (an H1->H3 jump is a skip), no level may be
+     skipped going deeper (e.g. H2 -> H4), and there must be no <h1> in the body.
+  2. WCAG 1.1.1 (Non-text Content) - image alternative text.
+     Every markdown image ![](...) and raw <img> must have non-empty alt text,
+     UNLESS (a) the image is a screenshots.tallyfy.com URL that has a caption in
+     documentation_assets.csv (the support-docs remark plugin injects that alt at
+     build time), or (b) a raw <img> is explicitly marked decorative
+     (role="presentation"/"none" or aria-hidden="true") - empty alt is then correct.
+  3. WCAG 2.2.2 (Pause, Stop, Hide) - D2 diagram animation.
+     No ```d2 fence may declare style.animated (dot or block notation); animated
+     "marching ants" connectors loop forever and cannot be paused (cf. #85, whose
+     remark plugin strips them - this stops the anti-pattern at the source).
+
+Scope/assumptions (validated against the current corpus, which has 0 of each):
+  - Only markdown '#' headings are evaluated; raw <hN> content headings and Setext
+    (underline) headings are not. The dist-level assertion is the rendered backstop.
+  - Reference-style images (![][ref]) are not alt-checked (corpus uses none).
+  - Fenced code (``` / ~~~), the frontmatter, and the auto-generated
+    "## Related articles" section onward are ignored for headings/D2.
+
+Exit 0 = clean, 1 = violations found (fails the pipeline).
+"""
+import argparse
+import csv
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+SKIP_FILES = {"404.mdx"}
+SKIP_DIR_PARTS = ["/changelog"]  # changelog is generated; matches markdown-lint.py
+
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
+HEADING_RE = re.compile(r"^(#{1,6})\s+\S")
+MD_IMG_RE = re.compile(r"!\[([^\]]*)\]\(\s*(<[^>]+>|[^)\s]+)[^)]*\)")
+IMG_TAG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+# Attribute regexes require a preceding whitespace/tag boundary so a literal like
+# data-x="alt='y'" cannot be mistaken for the alt attribute (regex, not a DOM parser).
+ALT_ATTR_RE = re.compile(r"""(?:^|\s)alt\s*=\s*(?:"([^"]*)"|'([^']*)')""", re.IGNORECASE)
+SRC_ATTR_RE = re.compile(r"""(?:^|\s)src\s*=\s*(?:"([^"]*)"|'([^']*)')""", re.IGNORECASE)
+DECORATIVE_RE = re.compile(
+    r"""(?:^|\s)(?:role\s*=\s*["'](?:presentation|none)["']|aria-hidden\s*=\s*["']true["'])""",
+    re.IGNORECASE,
+)
+D2_ANIMATED_RE = re.compile(r"(?:\bstyle\.animated\b|\banimated\s*:\s*true\b)")
+
+
+def attr_value(regex, tag):
+    """Return the matched attribute value as a stripped string ("" if the
+    attribute is absent OR present-but-empty). Handles empty double/single-quoted
+    values without crashing (group can be "" which is falsy)."""
+    m = regex.search(tag)
+    if not m:
+        return ""
+    val = m.group(1) if m.group(1) is not None else m.group(2)
+    return (val or "").strip()
+
+
+def load_captioned_urls(csv_path):
+    """Return set of production_url values (raw + URL-decoded) that have a non-empty
+    ai_caption_alt (these get alt injected at build, so an empty source alt is OK)."""
+    captioned = set()
+    if not csv_path or not os.path.isfile(csv_path):
+        return captioned
+    with open(csv_path, newline="", encoding="utf-8", errors="replace") as f:
+        for row in csv.DictReader(f):
+            url = (row.get("production_url") or "").strip()
+            alt = (row.get("ai_caption_alt") or "").strip()
+            if url and alt:
+                captioned.add(url)
+                captioned.add(unquote(url))  # match refs that use literal slashes
+    return captioned
+
+
+def is_captioned(url, captioned):
+    return url in captioned or unquote(url) in captioned
+
+
+def iter_mdx(base_dir):
+    for path, _subdirs, files in os.walk(base_dir):
+        norm = path.replace(os.sep, "/")
+        if any(part in norm for part in SKIP_DIR_PARTS):
+            continue
+        for fn in files:
+            if fn.endswith(".mdx") and fn not in SKIP_FILES:
+                yield os.path.join(path, fn)
+
+
+def frontmatter_line_count(text):
+    m = re.match(r"^---\n.*?\n---\n", text, re.DOTALL)
+    return text[: m.end()].count("\n") if m else 0
+
+
+def lint_file(fp, captioned):
+    """Return a list of (lineno, code, message) violations for one file."""
+    text = Path(fp).read_text(encoding="utf-8", errors="replace")
+    fm_lines = frontmatter_line_count(text)
+    lines = text.splitlines()
+
+    violations = []
+    in_fence = False
+    fence_char = None
+    fence_len = 0
+    fence_is_d2 = False
+    prev_level = None
+    first_heading_seen = False
+    related_reached = False
+
+    for i, line in enumerate(lines):
+        lineno = i + 1
+
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group(1)
+            marker_char = marker[0]
+            if not in_fence:
+                in_fence = True
+                fence_char = marker_char
+                fence_len = len(marker)
+                fence_is_d2 = fence_match.group(2).strip().lower().startswith("d2")
+                continue
+            # closing fence (CommonMark): same char, length >= opening, nothing after
+            if marker_char == fence_char and len(marker) >= fence_len and fence_match.group(2).strip() == "":
+                in_fence = False
+                fence_char = None
+                fence_len = 0
+                fence_is_d2 = False
+                continue
+            # otherwise a longer/info-bearing fence line inside the block - treat as content
+        if in_fence:
+            if fence_is_d2 and D2_ANIMATED_RE.search(line):
+                violations.append(
+                    (lineno, "2.2.2",
+                     "D2 fence declares style.animated (infinite animation); remove it "
+                     "(arrowheads convey direction). See #85.")
+                )
+            continue
+
+        if lineno <= fm_lines:
+            continue
+
+        heading_match = HEADING_RE.match(line)
+        if heading_match and not related_reached:
+            level = len(heading_match.group(1))
+            heading_text = line.lstrip("#").strip().lower()
+            if heading_text.startswith("related articles"):
+                related_reached = True  # stop heading checks at the generated section
+            else:
+                if level == 1:
+                    violations.append(
+                        (lineno, "1.3.1",
+                         "<h1> in body; the page title is already the H1. Start content at H2.")
+                    )
+                if not first_heading_seen:
+                    first_heading_seen = True
+                    if level != 2:
+                        violations.append(
+                            (lineno, "1.3.1",
+                             f"first content heading is H{level}; it must be H2 "
+                             f"(Starlight renders the title as H1, so H1->H{level} is a skip).")
+                        )
+                elif prev_level is not None and level > prev_level + 1:
+                    violations.append(
+                        (lineno, "1.3.1",
+                         f"heading level skip H{prev_level} -> H{level}; do not skip levels.")
+                    )
+                prev_level = level
+
+        # image alt text (markdown + raw <img>); checked everywhere, incl. after Related articles
+        for m in MD_IMG_RE.finditer(line):
+            alt = m.group(1).strip()
+            url = m.group(2).strip().strip("<>")
+            if not alt and not is_captioned(url, captioned):
+                violations.append(
+                    (lineno, "1.1.1",
+                     f"image has empty alt text and no caption in documentation_assets.csv: {url}")
+                )
+        for tag_m in IMG_TAG_RE.finditer(line):
+            tag = tag_m.group(0)
+            if DECORATIVE_RE.search(tag):
+                continue  # explicitly decorative: empty alt is correct, not a 1.1.1 failure
+            alt = attr_value(ALT_ATTR_RE, tag)
+            url = attr_value(SRC_ATTR_RE, tag)
+            if not alt and not is_captioned(url, captioned):
+                violations.append(
+                    (lineno, "1.1.1",
+                     f"<img> has empty/missing alt (and is not marked decorative) and no caption "
+                     f"in documentation_assets.csv: {url or '<no src>'}")
+                )
+
+    return violations
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Accessibility lint for documentation .mdx content")
+    parser.add_argument("--dir", required=True, help="Base directory to scan (repo root or content dir)")
+    parser.add_argument("--csv", default=None,
+                        help="Path to documentation_assets.csv (default: auto-detect under --dir)")
+    args = parser.parse_args()
+
+    base_dir = Path(args.dir)
+    if not base_dir.is_dir():
+        print(f"Invalid directory path: {args.dir}")
+        return 1
+
+    csv_path = args.csv
+    if not csv_path:
+        for candidate in ("documentation_assets.csv",
+                          os.path.join("..", "documentation_assets.csv")):
+            p = base_dir / candidate
+            if p.is_file():
+                csv_path = str(p)
+                break
+    captioned = load_captioned_urls(csv_path)
+    print(f"a11y-lint: scanning {base_dir}  (captioned-image URLs loaded: {len(captioned)})")
+
+    total = 0
+    bad_files = 0
+    for fp in sorted(iter_mdx(str(base_dir))):
+        violations = lint_file(fp, captioned)
+        if violations:
+            bad_files += 1
+            print(f"\n{fp}")
+            for lineno, code, msg in violations:
+                total += 1
+                print(f"  L{lineno} [WCAG {code}] {msg}")
+
+    print(f"\na11y-lint: {total} violation(s) across {bad_files} file(s).")
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/content/docs/manufactory/collector/rest_api/send_events.mdx
+++ b/src/content/docs/manufactory/collector/rest_api/send_events.mdx
@@ -12,13 +12,13 @@ title: Send events via the REST API
 
 You can send actor profiles to Tallyfy Manufactory using the endpoint `POST /events`.
 
-### Required keys
+## Required keys
 
 - `org_id` (required) string - Manufactory org ID.
 - `project_id` (required) number - The project ID associated with this schema.
 - `actor_profile` (required) object - Attribute name-value pairs. Make sure you're using the correct names and data types from [Get Actors schema](/products/manufactory/actors/get_schema/).
 - `attributes` (required) object - Attribute name-value pairs. Make sure you're using the correct names and data types from [Get events schema](/products/manufactory/events/get_schema/).
-### Request example
+## Request example
 ```json
 {
   "org_id": "demo",
@@ -38,7 +38,7 @@ You can send actor profiles to Tallyfy Manufactory using the endpoint `POST /eve
 }
 ```
 
-### Response example
+## Response example
 
 ```json
 {

--- a/src/content/docs/manufactory/collector/websocket/auth.mdx
+++ b/src/content/docs/manufactory/collector/websocket/auth.mdx
@@ -18,13 +18,13 @@ Required header:
 
 - `X-Manufactory-Auth` - Project key of the project to be populated.
 
-### Required keys
+## Required keys
 
 - `org_id` (required) string - Manufactory org ID.
 - `project_id` (required) number - The project ID associated with this schema.
 - `actor_profile` (required) object - Key-value pairs with the correct attribute names and data types. See [Get Actors schema](/products/manufactory/actors/get_schema/).
 
-### Request example
+## Request example
 ```json
 {
   "org_id": "xyz",
@@ -39,7 +39,7 @@ Required header:
 }
 ```
 
-### Response example
+## Response example
 
 ```json
 {

--- a/src/content/docs/manufactory/collector/websocket/send_events.mdx
+++ b/src/content/docs/manufactory/collector/websocket/send_events.mdx
@@ -12,12 +12,12 @@ title: Send events via websocket
 
 Once you've established a websocket connection with Tallyfy Manufactory[^1], you can start sending user-generated events through the open channel.
 
-### Required keys
+## Required keys
 
 - `type` (required) string - The message type. Here we'll use `event`.
 - `attributes` (required) object - Key-value pairs with attribute names and their values. Make sure you're using the correct attribute names and data types. See [get events schema](/products/manufactory/events/get_schema/).
 
-### Websocket message example
+## Websocket message example
 ```json
 {
   "type": "event",
@@ -29,7 +29,7 @@ Once you've established a websocket connection with Tallyfy Manufactory[^1], you
 }
 ```
 
-### Websocket reply example
+## Websocket reply example
 
 ```json
 {

--- a/src/content/docs/manufactory/events/delete_schema.mdx
+++ b/src/content/docs/manufactory/events/delete_schema.mdx
@@ -11,12 +11,12 @@ title: Delete events schema
 
 Here's the endpoint to delete an event schema in Tallyfy Manufactory: `DELETE /events/schema/{org_id}/{project_id}`.
 
-### Authentication
+## Authentication
 
 You'll need this header for all API calls:
 - `X-Manufactory-Auth` - Manufactory access token
 
-### Required values
+## Required values
 
 - `org_id` (required) string - Manufactory org ID.
 - `project_id` (required) number - Manufactory project ID.

--- a/src/content/docs/manufactory/events/get_schema.mdx
+++ b/src/content/docs/manufactory/events/get_schema.mdx
@@ -11,12 +11,12 @@ title: Get events schema
 
 You can fetch an events schema for a specific project in Tallyfy Manufactory using `GET /events/schema/{org_id}/{project_id}`.
 
-### Authentication
+## Authentication
 
 You'll need this header for all API calls:
 - `X-Manufactory-Auth` - Manufactory access token
 
-### Required values
+## Required values
 
 Both values are required. They can't be omitted.
 
@@ -24,7 +24,7 @@ Both values are required. They can't be omitted.
 - `project_id` number - Manufactory project ID.
 
 
-### Response example
+## Response example
 
 ```json
 {

--- a/src/content/docs/manufactory/projects/create_project.mdx
+++ b/src/content/docs/manufactory/projects/create_project.mdx
@@ -11,20 +11,20 @@ title: Create a project
 
 You can create a project in Tallyfy Manufactory using the endpoint `POST /projects`.
 
-### Authentication
+## Authentication
 
 You'll need this header for all API calls:
 
 * `X-Manufactory-Auth` - Manufactory access token
 
-### Required keys
+## Required keys
 
 * `org_id` (required) string - Manufactory org ID.
 * `name` (required) string - The desired project name.
 * `description` (required) string - A description for the project.
 * `timezone` (required) string - The preferred timezone for displaying dates. For example, `New York (Eastern)` would be `America/New_York`. Here's a complete list of [valid timezones](https://go.tallyfy.com/resources/timeZone.json). (Timestamps are stored in UTC; this setting doesn't affect storage, only display.)
 
-### Request example
+## Request example
 
 ```json
 {
@@ -35,7 +35,7 @@ You'll need this header for all API calls:
 }
 ```
 
-### Response example
+## Response example
 
 ```json
 {

--- a/src/content/docs/manufactory/projects/delete_project.mdx
+++ b/src/content/docs/manufactory/projects/delete_project.mdx
@@ -11,12 +11,12 @@ title: Delete a project
 
 To delete a project, you'll use the endpoint `DELETE /projects/{org_id}/{project_id}`.
 
-### Authentication
+## Authentication
 
 Here's the required header for all API calls:
 - `X-Manufactory-Auth` - Manufactory access token
 
-### Required values
+## Required values
 
 - `org_id` (required) string - Manufactory org ID.
 - `project_id` (required) number - Manufactory project ID.

--- a/src/content/docs/manufactory/projects/get_project.mdx
+++ b/src/content/docs/manufactory/projects/get_project.mdx
@@ -12,19 +12,19 @@ title: Get a project
 
 You can get a specific Manufactory project using the endpoint `GET /projects/{org_id}/{project_id}`.
 
-### Authentication
+## Authentication
 
 You'll need this header for all API calls:
 - `X-Manufactory-Auth` - Manufactory access token
 
 
-### Required values
+## Required values
 
 - `org_id` (required) string - Manufactory org ID.
 - `project_id` (required) number - Manufactory project ID.
 
 
-### Response example
+## Response example
 
 ```json
   {

--- a/src/content/docs/manufactory/projects/get_projects.mdx
+++ b/src/content/docs/manufactory/projects/get_projects.mdx
@@ -12,17 +12,17 @@ title: Get all projects
 
 To get all your Manufactory projects, you'll use the endpoint `GET /projects/{org_id}`.
 
-### Authentication
+## Authentication
 
 You'll need this header for all API calls:
 - `X-Manufactory-Auth` - Manufactory access token
 
-### Required values
+## Required values
 
 - `org_id` (required) string - Manufactory org ID.
 
 
-### Response example
+## Response example
 
 ```json
 [

--- a/src/content/docs/manufactory/projects/reset_key.mdx
+++ b/src/content/docs/manufactory/projects/reset_key.mdx
@@ -11,7 +11,7 @@ title: Reset project key
 
 You can reset a project's key using `POST /projects/{org_id}/{project_id}/keys`.
 
-### Authentication
+## Authentication
 
 You'll need this header for all API calls:
 - `X-Manufactory-Auth` - Manufactory access token
@@ -21,7 +21,7 @@ You'll need this header for all API calls:
 - `org_id` (required) string - Manufactory org ID.
 - `project_id` (required) number - Manufactory project ID.
 
-### Response example
+## Response example
 
 ```json
 {

--- a/src/content/docs/manufactory/use-cases.mdx
+++ b/src/content/docs/manufactory/use-cases.mdx
@@ -14,7 +14,7 @@ title: Use cases and Pro integration
 
 Tallyfy Manufactory complements Tallyfy Pro by adding event lifecycle capabilities to your workflow management. This integration enhances automation and provides real-time insights. Here's a step-by-step approach:
 
-#### Smooth integration of event handling
+### Smooth integration of event handling
 
 1. Better workflow automation
    Triggering workflows:
@@ -33,7 +33,7 @@ Tallyfy Manufactory complements Tallyfy Pro by adding event lifecycle capabiliti
    - Implementation: Develop dynamic adjustment capabilities in Tallyfy workflows that respond to real-time event changes from Tallyfy Manufactory.
    - Example: If a critical temperature threshold is exceeded in a manufacturing process, automatically escalate the workflow to involve senior engineers.
 
-#### Enhancing user experience
+### Enhancing user experience
 
 1. Intelligent reminders:
    - Implementation: Use event data from Tallyfy Manufactory to send context-aware reminders in Tallyfy.
@@ -43,7 +43,7 @@ Tallyfy Manufactory complements Tallyfy Pro by adding event lifecycle capabiliti
    - Implementation: Set up a system in Tallyfy to send proactive alerts based on predictive analysis from event data.
    - Example: Alert users about potential equipment failure based on trends in the time-series data[^2].
 
-#### Expanding use cases and capabilities
+### Expanding use cases and capabilities
 
 1. Tailored solutions:
    - Implementation: Develop industry-specific templates that combine event data from Tallyfy Manufactory with workflows in Tallyfy.
@@ -58,7 +58,7 @@ Tallyfy Manufactory complements Tallyfy Pro by adding event lifecycle capabiliti
    Implementation: Provide strong APIs for developers to use the combined functionalities of Tallyfy Manufactory and the Tallyfy app.
    Example: Allow external applications to trigger workflows in Tallyfy based on custom events processed by Tallyfy Manufactory.
 
-#### Advanced data handling and analytics
+### Advanced data handling and analytics
 
 1. Data ingestion and querying:
    - Implementation: Use Tallyfy Manufactory's strong data ingestion capabilities to feed detailed event data into Tallyfy's analytics modules.

--- a/src/content/docs/pro/compliance/bimi-compliance.mdx
+++ b/src/content/docs/pro/compliance/bimi-compliance.mdx
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 Tallyfy uses BIMI to display a verified logo next to emails sent from `tallyfy.com`. If you see the Tallyfy logo in your inbox, that email is genuinely from us. No logo? Don't trust it.
 
-### How does BIMI authentication work?
+## How does BIMI authentication work?
 
 BIMI checks multiple forms of identity before showing our logo next to a message. Here's how it works:
 
@@ -36,19 +36,19 @@ BIMI checks multiple forms of identity before showing our logo next to a message
     When Gmail or Outlook receives an email from `tallyfy.com`, it runs through all these checks. Pass every one? The logo appears. Fail any? No logo.
 </Steps>
 
-### What security benefits does BIMI give you?
+## What security benefits does BIMI give you?
 
 *   **Instant trust signal:** See the Tallyfy logo? It's really us. No logo on an email claiming to be from Tallyfy? Delete it.
 *   **Faster recognition:** The Tallyfy logo makes our emails stand out in a crowded inbox, so you can spot them quickly.
 *   **Phishing resistance:** Over time, you'll instinctively expect the logo on legitimate Tallyfy emails - making fakes obvious.
 
-### How does BIMI protect against cyber threats?
+## How does BIMI protect against cyber threats?
 
 *   **Domain spoofing prevention:** Someone sends a fake "password reset" from a spoofed tallyfy.com address. No logo appears, and the email goes to spam.
 *   **Phishing detection:** An urgent "Update your payment method NOW!" email arrives without the Tallyfy logo. That's your red flag - real Tallyfy emails always show the verified logo.
 *   **Brand impersonation resistance:** Scammers can copy Tallyfy's website design, but they can't fake the BIMI certificate. You can immediately spot fraudulent emails by the missing logo.
 
-### What should I know about custom SMTP settings?
+## What should I know about custom SMTP settings?
 
 :::caution[Using custom SMTP disables BIMI benefits]
 When you configure Tallyfy to send emails via your **own email server (Custom SMTP)** instead of Tallyfy servers (`tallyfy.com`), the BIMI logo **will not appear** on those emails.

--- a/src/content/docs/pro/compliance/hsts-compliance.mdx
+++ b/src/content/docs/pro/compliance/hsts-compliance.mdx
@@ -12,24 +12,24 @@ title: HSTS compliance
 
 HSTS forces your browser to use encrypted connections only. It blocks any attempt to connect to Tallyfy without HTTPS - even if someone tricks you into clicking an `http://` link, your browser upgrades it automatically.
 
-### How does HSTS work?
+## How does HSTS work?
 
 When you first visit Tallyfy over **HTTPS**, your browser receives a `Strict-Transport-Security` header. This tells the browser: "Always use encryption with Tallyfy - no exceptions."
 
 Your browser remembers this for one year[^3]. Even if you type `http://` instead of `https://`, the browser catches it before sending any data.
 
-### How does Tallyfy use HSTS preloading?
+## How does Tallyfy use HSTS preloading?
 
 Tallyfy is on the **HSTS preload list[^1]** - hardcoded into Chrome, Firefox, Safari, and other major browsers. Your browser already knows to use HTTPS with Tallyfy **before you even visit for the first time**. There's no window of vulnerability. Not even for a millisecond.
 
-### What attacks does HSTS prevent?
+## What attacks does HSTS prevent?
 
 *   **SSL stripping[^2]:** Attackers try to downgrade your connection to plain HTTP. HSTS blocks this - your browser upgrades to HTTPS before any data leaves your device.
 *   **Man-in-the-middle exploits:** Someone sitting between you and Tallyfy, pretending to be us? Your browser won't accept anything but a verified, encrypted connection.
 *   **Session hijacking:** Login cookies and authentication tokens only travel over encrypted channels. No exceptions. This matters most on public Wi-Fi, where attackers commonly try to intercept traffic.
 *   **Eavesdropping:** Every click, form submission, and document you view is encrypted. Network admins, ISPs, and nearby devices can't see what you're doing in Tallyfy.
 
-### What are HSTS requirements?
+## What are HSTS requirements?
 
 Tallyfy meets all seven requirements for proper HSTS:
 

--- a/src/content/docs/pro/documenting/groups/how-to-manage-groups-and-assign-tasks-in-tallyfy.mdx
+++ b/src/content/docs/pro/documenting/groups/how-to-manage-groups-and-assign-tasks-in-tallyfy.mdx
@@ -17,11 +17,11 @@ import { Audience } from "~/components";
 
 Groups let you bundle people together so you don't have to assign them to tasks one by one.
 
-### What you'll need
+## What you'll need
 - Admin or Standard [member](/products/pro/documenting/members/) permissions
 - Access to **Settings**
 
-### Creating a group
+## Creating a group
 
 <Steps>
 1. Go to **Settings** > **Organization** > **Groups**.
@@ -36,7 +36,7 @@ Groups let you bundle people together so you don't have to assign them to tasks 
 Create groups with guest emails you use often (like your client's team). You won't have to re-type those addresses every time.
 :::
 
-### Assigning groups to template steps
+## Assigning groups to template steps
 
 <Steps>
 1. Open a [template](/products/pro/documenting/templates/) and select the step ([task](/products/pro/tracking-and-tasks/tasks/)) you want to assign.
@@ -45,7 +45,7 @@ Create groups with guest emails you use often (like your client's team). You won
    ![Assigning a group to a task in Tallyfy](https://screenshots.tallyfy.com/tallyfy%2Fpro%2Fdesktop-light-assign-task-group.png)
 </Steps>
 
-### Group assignment options
+## Group assignment options
 
 - **Maximum assignees[^2]** - limits how many people from the group can work on one task. Set this at the organization level.
 - For dynamic assignments that change based on process conditions, use [assignment actions](/products/pro/documenting/templates/automations/actions/asignment-actions/).

--- a/src/content/docs/pro/documenting/groups/index.mdx
+++ b/src/content/docs/pro/documenting/groups/index.mdx
@@ -14,11 +14,11 @@ import { Audience } from "~/components";
 
 <Audience to="editor" />
 
-### What are groups?
+## What are groups?
 
 Groups let you assign tasks to entire teams at once - saved lists of people you work with regularly. Pick the group instead of adding people one by one.
 
-#### Benefits
+### Benefits
 
 - **Faster task assignment** - one click assigns the whole team
 - **Consistent workflows** - same groups work across all your processes[^2]
@@ -27,7 +27,7 @@ Groups let you assign tasks to entire teams at once - saved lists of people you 
 
 If you're running the same workflows every week or month, groups save you from repetitive setup work.
 
-#### Group composition example
+### Group composition example
 
 An "Accounting Team" group might contain:
 - Jane Doe (member)
@@ -36,7 +36,7 @@ An "Accounting Team" group might contain:
 
 You can mix internal team members with external partners in the same group. Your auditor, consultant, or client can work right alongside your staff.
 
-#### Automatic membership management
+### Automatic membership management
 
 When someone leaves your company, Tallyfy removes them from every group automatically. No hunting through workflows to clean up assignments.
 

--- a/src/content/docs/pro/documenting/templates/edit-templates/change-template-state.mdx
+++ b/src/content/docs/pro/documenting/templates/edit-templates/change-template-state.mdx
@@ -15,7 +15,7 @@ import { Audience } from "~/components";
 
 <Audience to="editor" />
 
-### What template status means
+## What template status means
 
 A [template's](/products/pro/documenting/templates/) status tells your team whether it's still being built or ready to use. Tallyfy has 4 status options:
 
@@ -32,7 +32,7 @@ Status permissions work differently from editing permissions:
 - **Light members** - Can't edit templates, but they can still change status from the Templates list.
 :::
 
-### How to change template status
+## How to change template status
 
 **Method 1: From the Templates list**
 <Steps>

--- a/src/content/docs/pro/documenting/templates/organize-templates-into-folders.mdx
+++ b/src/content/docs/pro/documenting/templates/organize-templates-into-folders.mdx
@@ -15,7 +15,7 @@ import { Audience } from "~/components";
 
 <Audience to="editor" />
 
-### Why use template folders?
+## Why use template folders?
 
 Create folders in Tallyfy and move your templates into them. Once you've got 20+ templates, folders make finding the right workflow much faster.
 
@@ -23,7 +23,7 @@ Create folders in Tallyfy and move your templates into them. Once you've got 20+
 "Light" [members](/products/pro/documenting/members/) can't organize templates into folders. Only "Standard" members (if allowed by an Admin) or "Administrator" members can create folders and move templates.
 :::
 
-### Template folders vs. process folders
+## Template folders vs. process folders
 
 Tallyfy has two separate folder systems. They're independent of each other.
 
@@ -42,17 +42,17 @@ How you organize master templates often differs from how you organize live work.
 A template folder stays a template folder, and a process folder stays a process folder. Moving a folder doesn't change its type, so you can't accidentally turn a template folder into a process folder by dragging it. Folders sort by their assigned position, so the order you arrange them in stays consistent across reloads and across team members.
 :::
 
-#### What you need
+### What you need
 - Access to the **Templates** section
 - Standard or Admin permissions - Light members can't create folders
 
-#### Benefits
+### Benefits
 - **Find templates faster** - good folder structure cuts search time
 - **Group logically** - HR templates in one spot, sales workflows in another
 - **Cleaner view** - no more scrolling through an endless flat list
 - **Self-service** - new employees find what they need without asking
 
-#### Creating main folders
+### Creating main folders
 
 <Steps>
 1. Go to the **Templates** section
@@ -65,7 +65,7 @@ Your new folder appears in the left panel. Click it to open or start adding temp
 
 ![Template folders in the left panel of the Templates section](https://screenshots.tallyfy.com/tallyfy/pro/desktop-light-point-folders-templates.png)
 
-#### Creating subfolders
+### Creating subfolders
 
 <Steps>
 1. Click a parent folder in the left panel
@@ -76,7 +76,7 @@ Your new folder appears in the left panel. Click it to open or start adding temp
 
 Subfolders nest under their parent folder.
 
-#### Moving templates into folders
+### Moving templates into folders
 
 <Steps>
 1. Find the [template](/products/pro/documenting/templates/) you want to move
@@ -86,7 +86,7 @@ Subfolders nest under their parent folder.
 5. Click **Move**
 </Steps>
 
-#### Managing existing folders
+### Managing existing folders
 
 <Steps>
 1. Click the folder you want to manage in the left panel
@@ -101,7 +101,7 @@ Subfolders nest under their parent folder.
 
 *Deleting a folder does **not** delete the templates inside it. They move back to the main library view (unfoldered).*
 
-#### Restoring archived templates
+### Restoring archived templates
 
 When you unarchive a [template](/products/pro/documenting/templates/), Tallyfy remembers its original folder:
 - If the folder still exists, the template goes back there
@@ -114,7 +114,7 @@ When you unarchive a [template](/products/pro/documenting/templates/), Tallyfy r
    ![Archived templates tab with unarchive option](https://screenshots.tallyfy.com/tallyfy%2Fpro%2Fdesktop-light-show-archived-templates1701483092924.png)
 </Steps>
 
-#### Best practices
+### Best practices
 
 Keep folder names short and obvious - "HR Templates" beats "Human Resources Documentation and Processes." Two or three levels of nesting works well. More than that creates a maze.
 

--- a/src/content/docs/pro/integrations/open-api/access-api-as-a-third-party-application-instead-of-a-user.mdx
+++ b/src/content/docs/pro/integrations/open-api/access-api-as-a-third-party-application-instead-of-a-user.mdx
@@ -107,7 +107,7 @@ App -> User: "10. Return result\nto user" {
 - Both user provisioning and user token generation need that app-level token. This creates a chain of trust
 - App tokens manage users. User tokens perform workflow actions. They're distinct on purpose.
 
-#### Step 1 - Get client credentials
+### Step 1 - Get client credentials
 
 <Steps>
 1. Contact Tallyfy Support and describe your integration use case
@@ -115,7 +115,7 @@ App -> User: "10. Return result\nto user" {
 3. Store these credentials securely (environment variables, secrets manager, etc.)
 </Steps>
 
-#### Step 2 - Get an application access token
+### Step 2 - Get an application access token
 
 Send a POST request to get your app-level token.
 
@@ -149,7 +149,7 @@ Content-Type: application/x-www-form-urlencoded
 App tokens last 7 days (604,800 seconds). Request a fresh token before the current one expires. There's no separate refresh endpoint.
 :::
 
-#### Step 3 - Provision users
+### Step 3 - Provision users
 
 Create users in your Tallyfy organization using the app token.
 
@@ -196,7 +196,7 @@ Both `first_name` and `last_name` are required (max 32 characters each). The `ro
 }
 ```
 
-#### Step 4 - Generate user-specific tokens
+### Step 4 - Generate user-specific tokens
 
 To act as a specific user, request a token for their email address.
 
@@ -226,7 +226,7 @@ No request body needed. The email goes in the URL path. The user must already ex
 User tokens last 3 months (7,776,000 seconds). Build your refresh logic around this timeline.
 :::
 
-#### Step 5 - Make API calls as that user
+### Step 5 - Make API calls as that user
 
 Use the user-specific token for any Tallyfy API call. It works exactly as if the user made the request themselves.
 

--- a/src/content/docs/pro/integrations/open-api/code-samples/authentication/index.mdx
+++ b/src/content/docs/pro/integrations/open-api/code-samples/authentication/index.mdx
@@ -18,7 +18,7 @@ Every Tallyfy API request needs authentication. Pick the method that fits your u
 - **Personal access token** -- grab your token from **Settings > Integrations > REST API** in Tallyfy and pass it in the `Authorization` header. Tokens last 6 months and act as the logged-in user. Best for scripts, testing, and quick integrations.
 - **Client credentials flow** -- use a `client_id` and `client_secret` (provided by Tallyfy Support) to get an application-level token via `POST https://go.tallyfy.com/oauth/token`. App tokens last 7 days. Best for backend services that don't need a user session.
 
-### Required headers
+## Required headers
 
 Include these three headers on every API call:
 

--- a/src/content/docs/pro/integrations/open-api/code-samples/processes/launch-process-without-template.mdx
+++ b/src/content/docs/pro/integrations/open-api/code-samples/processes/launch-process-without-template.mdx
@@ -14,7 +14,7 @@ title: Launch projects
 import { CardGrid, LinkTitleCard } from "~/components";
 import { Aside, Card, TabItem, Tabs } from "@astrojs/starlight/components";
 
-# Launch a process as an "empty shell" project
+## Launch a process as an "empty shell" project
 
 Normally in Tallyfy, you'd create a template and then launch it. But sometimes you need an ad-hoc project -- just a one-time set of tasks you want to track like a regular process.
 

--- a/src/content/docs/pro/integrations/open-api/code-samples/templates/delete-archive-template.mdx
+++ b/src/content/docs/pro/integrations/open-api/code-samples/templates/delete-archive-template.mdx
@@ -18,29 +18,29 @@ There are two ways to remove a template via the API:
 1.  **Archive (soft delete):** Hides the template but keeps its data. Processes already launched from it keep running. Archived templates can be restored.
 2.  **Delete (permanent):** Permanently removes the template and its associated data. This can't be undone. The template must be archived first before it can be permanently deleted.
 
-### 1. Archive a template
+## 1. Archive a template
 
-#### Endpoint
+### Endpoint
 
 `DELETE /organizations/{org_id}/checklists/{checklist_id}`
 
 This archives the specified template (soft delete).
 
-#### Request
+### Request
 
 Replace `{org_id}` with your Organization ID and `{checklist_id}` with the template ID.
 
-##### Headers
+#### Headers
 
 -   `Authorization: Bearer {your_access_token}`
 -   `Accept: application/json`
 -   `X-Tallyfy-Client: APIClient`
 
-##### Body
+#### Body
 
 No request body is needed.
 
-#### Code samples
+### Code samples
 
 <Tabs>
 <TabItem label="JavaScript (fetch)">
@@ -228,7 +228,7 @@ func main() {
 </TabItem>
 </Tabs>
 
-#### Response
+### Response
 
 A successful archive returns `200 OK` with a confirmation message and a list of deleted references (e.g., from automations or recurring jobs that referenced this template).
 
@@ -239,33 +239,33 @@ A successful archive returns `200 OK` with a confirmation message and a list of 
 }
 ```
 
-### 2. Permanently delete a template
+## 2. Permanently delete a template
 
 :::danger[Irreversible action]
 Permanently deleting a template can't be undone. All associated template data will be lost. The template must already be archived before you can permanently delete it. This endpoint requires admin permissions.
 :::
 
-#### Endpoint
+### Endpoint
 
 `DELETE /organizations/{org_id}/checklists/{checklist_id}/delete`
 
 Note the extra `/delete` path segment compared to the archive endpoint.
 
-#### Request
+### Request
 
 Replace `{org_id}` and `{checklist_id}` as appropriate.
 
-##### Headers
+#### Headers
 
 -   `Authorization: Bearer {your_access_token}`
 -   `Accept: application/json`
 -   `X-Tallyfy-Client: APIClient`
 
-##### Body
+#### Body
 
 No request body is needed.
 
-#### Code samples for delete
+### Code samples for delete
 
 <Tabs>
 <TabItem label="Javascript">
@@ -588,7 +588,7 @@ public class TallyfyTemplateDeleter
 </TabItem>
 </Tabs>
 
-#### Response
+### Response
 
 A successful permanent deletion returns `200 OK`. The response body contains a confirmation message and a list of deleted references. If the template isn't archived yet, you'll get an error - you must archive it first.
 

--- a/src/content/docs/pro/launching/launch-process-when-task-is-completed.mdx
+++ b/src/content/docs/pro/launching/launch-process-when-task-is-completed.mdx
@@ -17,14 +17,14 @@ import { Audience } from "~/components";
 
 You can configure any [task](/products/pro/tracking-and-tasks/tasks/) in a Tallyfy [template](/products/pro/documenting/templates/) to automatically launch a new [process](/products/pro/tracking-and-tasks/processes/) from a different template when that task completes. This is useful for multi-phase workflows, customer journeys, and team hand-offs.
 
-### When to use this
+## When to use this
 
 *   **Multi-phase projects** - finishing Phase 1 automatically starts Phase 2.
 *   **Customer journeys** - completing "Sales" launches "Onboarding".
 *   **Branching workflows** - an "Initial Review" task launches either "Approved Project" or "Further Review".
 *   **Team hand-offs** - a Sales task triggers a process for Operations.
 
-### How to set it up
+## How to set it up
 
 <Steps>
 1. Open the template containing the trigger task and edit it.
@@ -37,7 +37,7 @@ You can configure any [task](/products/pro/tracking-and-tasks/tasks/) in a Tally
 
 ![Launch process when task completed setting in the Advanced tab](https://screenshots.tallyfy.com/tallyfy%2Fpro%2Fdesktop-light-launch-process-when-task-completed.png)
 
-### Inject tasks instead of launching a new process
+## Inject tasks instead of launching a new process
 
 Instead of launching a separate process, you can inject the target template's tasks directly into the current running process. All injected steps appear after the trigger task, keeping everything in one place.
 
@@ -52,7 +52,7 @@ Instead of launching a separate process, you can inject the target template's ta
 Injecting adds all steps from the target template into the current process instance, right after the trigger task. Everything stays in the same process - just with added steps. You can't inject from the same template twice.
 :::
 
-### Which templates can be launched or injected?
+## Which templates can be launched or injected?
 
 The dropdown only shows templates that:
 * Are active (not archived or deleted).
@@ -63,7 +63,7 @@ The dropdown only shows templates that:
 If a template isn't listed, check that it's active, has no required kick-off fields, and isn't a Document-type template.
 :::
 
-### Naming the launched process
+## Naming the launched process
 
 You can control the name of the automatically launched process:
 
@@ -72,14 +72,14 @@ You can control the name of the automatically launched process:
 
 ![Custom naming options for an automatically launched process](https://screenshots.tallyfy.com/tallyfy%2Fpro%2Fdesktop-light-custom-naming-process.png)
 
-### Limitations
+## Limitations
 
 * **Naming variables** - only DATE, TEMPLATE_NAME, and text-type kick-off form fields from the trigger process are available for custom naming.
 * **Passing data** - there's no built-in way to pass data from the trigger process to the launched process (other than via the name). For complex data transfer, use the Tallyfy [API](/products/pro/integrations/open-api/) or [webhooks](/products/pro/integrations/webhooks/) with [middleware](/products/pro/integrations/middleware/).
 * **Referencing data** - you can't reference data between original and injected tasks when using injection.
 * **Duplicate prevention** - if a process was already launched from a specific task, it won't launch again. Tallyfy adds a comment explaining this.
 
-### Tracking the connection
+## Tracking the connection
 
 Tallyfy automatically links trigger and launched processes:
 

--- a/src/content/docs/pro/launching/triggers/magic-links.mdx
+++ b/src/content/docs/pro/launching/triggers/magic-links.mdx
@@ -36,12 +36,12 @@ Magic links can't bypass required kick-off form fields. If your template has req
 - Use middleware platforms that programmatically supply required values
 :::
 
-### Access the magic link generator
+## Access the magic link generator
 
 1. Go to **Settings** > **Integrations**.
 2. Find the **Magic Links** card and click **Get a Magic Link**.
 
-### Available actions
+## Available actions
 
 | Action | What it does |
 |--------|-------------|
@@ -53,7 +53,7 @@ Magic links can't bypass required kick-off form fields. If your template has req
 | Edit task deadline | Updates the due date of a task |
 | Update form field value | Changes a form field value on a task |
 
-### Create a magic link to launch a process
+## Create a magic link to launch a process
 
 1. Click **Get a Magic Link** in the Magic Links card.
 2. Choose **Launch a process**.
@@ -62,14 +62,14 @@ Magic links can't bypass required kick-off form fields. If your template has req
 5. Copy the generated URL.
 6. Optionally add more parameters manually to pre-fill [kick-off fields](/products/pro/launching/triggers/kick-off-forms/).
 
-### Create a magic link for one-off tasks
+## Create a magic link for one-off tasks
 
 1. Click **Get a Magic Link**.
 2. Choose **Create a one-off task**.
 3. Set the default task name.
 4. Copy the generated URL.
 
-### Magic link URL structure
+## Magic link URL structure
 
 A link to launch a process and pre-fill data follows this pattern:
 
@@ -87,7 +87,7 @@ https://go.tallyfy.com/[YourOrgID]/process/[TemplateID]/create?default_run_name=
 If your template has auto-naming enabled, Tallyfy generates the process name from kick-off field values using the `default_process_name_format` set on the template. The auto-generated name can't exceed 550 characters. You'll still need to provide all required kick-off fields in `ko_fields`, or the launch will fail.
 :::
 
-### Field value syntax
+## Field value syntax
 
 Use this format for `ko_fields` values (before URL-encoding):
 
@@ -99,7 +99,7 @@ Use this format for `ko_fields` values (before URL-encoding):
 | Radio button | `"Selected Radio Value"` |
 | Date/Time | `"YYYY-MM-DDTHH:mm:ss.SSSZ"` (UTC format) |
 
-### Other action examples
+## Other action examples
 
 Replace `[YourOrgID]` and `[TaskID]` with your actual values. All task-based actions use the `/:org_id/magic` URL path.
 
@@ -110,7 +110,7 @@ Replace `[YourOrgID]` and `[TaskID]` with your actual values. All task-based act
 - **Edit deadline:** `...?action=editDeadline&task_id=[TaskID]&deadline=YYYY-MM-DDTHH:mm:ss.SSSZ`
 - **Update form field:** `...?action=updateFormFieldValue&task_id=[TaskID]&form_fields={"fieldId123":"New+Value"}`
 
-### Pre-fill public kick-off forms
+## Pre-fill public kick-off forms
 
 You can pre-fill fields on public kick-off forms using the same `ko_fields` and `default_run_name` parameters. The public form URL follows this pattern:
 
@@ -142,7 +142,7 @@ This is useful when you want to embed application links on your website with spe
 
 When a visitor clicks this link, they enter their email for verification, then see the kick-off form with the property name already selected. The same `ko_fields` JSON format works for both logged-in and public kick-off forms.
 
-### Where to use magic links
+## Where to use magic links
 
 - Buttons or links in emails (e.g., "Click here to approve")
 - Links on your company intranet

--- a/src/content/docs/pro/launching/triggers/via-email.mdx
+++ b/src/content/docs/pro/launching/triggers/via-email.mdx
@@ -17,7 +17,7 @@ import { Audience } from "~/components";
 
 Send an email to a template's unique address to start a process without logging into Tallyfy. This works well for mobile users or when you're working from external systems.
 
-### Prerequisites
+## Prerequisites
 
 - Permission to edit templates
 - No **required** kick-off form fields in the template (optional fields are fine)
@@ -27,7 +27,7 @@ Send an email to a template's unique address to start a process without logging 
 Email triggers **don't work** if the template has any kick-off form fields marked as **Required**. You'll get a failure notification email. Only use templates with optional (or no) kick-off fields for email launching.
 :::
 
-### Setting up email triggers
+## Setting up email triggers
 
 Each template gets its own unique email address.
 
@@ -41,7 +41,7 @@ Each template gets its own unique email address.
 6. Share this address with team members who need to launch this process via email.
 </Steps>
 
-### What happens when an email arrives
+## What happens when an email arrives
 
 1. Tallyfy checks if the sender is an active member in your organization. Non-members get a rejection email.
 2. If verified, Tallyfy launches a new process from the linked template.


### PR DESCRIPTION
## What

Phase-5 accessibility CI guardrail for the documentation lane (epic #66), plus the heading-structure content fixes the new lint surfaces.

- **`scripts/a11y-lint.py`** (new) wired into the `validate-markdown` job of `documentation-pipeline.yml`. Lints `.mdx` for:
  - **WCAG 1.3.1** heading structure — first content heading must be `<h2>` (Starlight renders the frontmatter `title` as the page `<h1>`, so content starting at `<h3>` is a rendered H1→H3 skip), no level skipped going deeper, no `<h1>` in body.
  - **WCAG 1.1.1** image alt — markdown `![](…)` and raw `<img>` need non-empty alt, exempting `screenshots.tallyfy.com` images that carry a caption in `documentation_assets.csv` (alt injected at build) and explicitly-decorative `<img>` (`role="presentation"`/`aria-hidden="true"`).
  - **WCAG 2.2.2** — no ```d2 fence may declare `style.animated`.
- **24 `.mdx` heading fixes** — heading levels renormalized so every page's first content heading is `<h2>` with no skips. Only the `#` prefix changed; heading text, the `## Related articles` section, and line endings are byte-identical (`git diff --numstat` shows equal add==del per file).

Pairs with the support-docs dist-level assertion (companion PR) that guards the rendered output (`<th>` scope #68, D2 alt #67, D2 animation #85).

## Verification

- Source lint: **0 violations** on 589 `.mdx` after the fixes (was 25/24 files).
- Rendered result verified live in a fresh `dist` build (725pp, links valid): heading sequences are skip-free across every fix-mode (`get_project` H1→H2→H2→H2, `groups` H1→H2→H3→H3, etc.).
- Regression-catch harness: **23/23** — each rule fails on an injected regression and passes on clean/decorative/CSV-captioned input.
- Independent adversarial (Opus) review: a crash on `<img alt="">` was caught and fixed before this PR.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation heading markup only; no runtime app, auth, or data-path changes. New lint may fail future PRs that introduce bad headings or missing alts.
> 
> **Overview**
> Adds **source-level accessibility checks** to the documentation pipeline and **renormalizes headings** across 24 MDX pages so they pass the new rules.
> 
> The `validate-markdown` job now runs **`scripts/a11y-lint.py`** after the existing markdown lint. The script scans `.mdx` for WCAG **1.3.1** (first body heading must be H2, no skipped levels, no H1 in body—Starlight uses `title` as H1), **1.1.1** (non-empty image alt, with CSV-caption and decorative `<img>` exemptions), and **2.2.2** (no animated D2 fences). Failures exit non-zero and block the pipeline.
> 
> **Content fixes** are heading-depth only: `###`/`####`/`#` prefixes were adjusted to `##`/`###`/`##` where pages started sections too deep or used a body H1. Manufactory API docs, compliance pages, groups/templates, Open API samples, and launching/trigger articles are among the touched files; wording and `## Related articles` are unchanged.
> 
> This complements dist-level a11y assertions in support-docs by catching issues before sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 123641445635a15cb254bda4e0b5d9f61aa37cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->