### PR TITLE
Add docs accessibility statement page (a11y-vpat #73)

### DIFF
--- a/src/content/docs/pro/miscellaneous/terms-legals/accessibility-statement.mdx
+++ b/src/content/docs/pro/miscellaneous/terms-legals/accessibility-statement.mdx
@@ -1,0 +1,62 @@
+---
+about_tallyfy: true
+description: Tallyfy's product documentation aims to meet the WCAG 2.2 Level AA accessibility
+  standard. See what's built into the docs, the one issue we're still fixing, and
+  how to report a problem you run into.
+id: dd2531ddf9712e2cf7f150e2d6aef783
+lastUpdated: 2026-06-19
+sidebar:
+  order: 5
+title: Accessibility statement
+---
+
+## We want everyone to use these docs
+
+Tallyfy's product documentation should work for everyone, including people who browse with a keyboard alone, a screen reader, screen magnification, voice control, or another assistive technology. This page explains how accessible the docs are today, what we've built in, and how to reach us if something gets in your way.
+
+## How accessible these docs are
+
+These docs aim to meet WCAG 2.2 Level AA. That's the accessibility standard most governments and large buyers ask for, and it's the same level Tallyfy targets across the rest of the product.
+
+Today the documentation site meets that level, with one known exception we're still working on (see the next section). We recheck this as we add and change pages, so it stays true over time.
+
+## What's built in
+
+You don't have to switch any of this on. It's part of every page:
+
+*   You can reach and operate every link, button, and menu with the keyboard alone.
+*   Headings, lists, and tables are marked up so a screen reader announces them correctly.
+*   Text and controls meet AA contrast targets in both light and dark mode.
+*   Links say where they go, so they still make sense when read on their own.
+*   Diagrams carry a text description, and none of them flash or loop.
+*   Footnote markers and the copy buttons are large enough to tap on a phone.
+*   Dark mode and your browser's text zoom both work without breaking the layout.
+
+## Known issues we're still fixing
+
+We'd rather be honest than tidy, so here's the one thing that isn't fully fixed:
+
+*   **The search results panel.** When you open search, a couple of links inside the results are nested in a way that some screen readers read awkwardly, and the highlight color on a matched result sits a little low on contrast. The search box itself is fully keyboard-operable, and you can open and read any page directly without using search at all. We're fixing this in the shared search component.
+
+If you run into anything else that's hard to use, please tell us (the next section shows how). We treat it as a bug.
+
+## Tell us about a problem
+
+Found a page that's hard to read or use? Email us at [support@tallyfy.com](mailto:support@tallyfy.com). Tell us the address of the page and what went wrong, and add the browser or assistive technology you were using if you can. We read every message, and we'll fix the page or get you the same information another way.
+
+## More about Tallyfy and accessibility
+
+This page covers the documentation site. For accessibility across the rest of Tallyfy, and to request a full accessibility conformance report (a VPAT), see Tallyfy's main accessibility page at [https://tallyfy.com/legal/accessibility/](https://tallyfy.com/legal/accessibility/).
+
+## Technical details
+
+For anyone who wants the specifics: the docs are built with standard HTML, CSS, and JavaScript, and we use ARIA only where a plain HTML element won't do the job. We test against WCAG 2.2 Level A and AA with a mix of automated and manual checks. The automated checks run the axe testing engine in both light and dark mode. The manual checks cover keyboard-only navigation and a review of the accessibility tree that screen readers read from. We test in current versions of Chrome, Firefox, Safari, and Edge. This statement was last reviewed in June 2026.
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+## Related articles
+<CardGrid>
+<LinkTitleCard header="<b>Miscellaneous > Terms & legals</b>" href="/products/pro/miscellaneous/terms-legals/" > Tallyfy provides enterprise security and legal compliance with SOC 2 Type 2 attestation, GDPR support, and custom data processing agreements. </LinkTitleCard>
+<LinkTitleCard header="<b>Pro > Compliance</b>" href="/products/pro/compliance/" > Tallyfy maintains a current SOC 2 Type 2 attestation with bank-level encryption and operational safeguards. </LinkTitleCard>
+<LinkTitleCard header="<b>Miscellaneous > Privacy policy</b>" href="/products/pro/miscellaneous/terms-legals/where-can-i-find-tallyfys-privacy-policy/" > Tallyfy's privacy policy explains how we collect, use, and protect your personal information. </LinkTitleCard>
+</CardGrid>


### PR DESCRIPTION
## What

Adds a new Starlight content page — the documentation site's **accessibility statement** (the docs ACR-equivalent), under Pro > Miscellaneous > Terms & legals.

`Closes tallyfy/documentation#73` (epic #66, documentation a11y-vpat lane).

## Why

The WCAG 2.2 AA remediation of the docs site is complete except for one upstream item (#87). A public accessibility statement is the program deliverable that (a) states conformance honestly, (b) lists what's built in, (c) gives users a way to report problems, and (d) links to the corporate hub at tallyfy.com/legal/accessibility/.

## Content

Business-reader plain language (passes simplicity-check, FK-grade 7.2). Honestly discloses the one known exception (the upstream search-results panel, #87). Feedback contact `support@tallyfy.com`. Standards/testing jargon demoted to a "Technical details" section.

## Verification

- **axe-core (WCAG A+AA), rendered DOM, scoped to content: 0 violations LIGHT and 0 DARK.**
- 1.3.1 H1+H2 hierarchy no skips; 1.4.3 contrast >=4.5:1 both modes (body 11.73/19.44); 2.4.7 visible focus ring (real keyboard + screenshot); all links named/focusable, zero nested-interactive.
- Production `astro build`: 726pp, all internal links valid, #72 a11y-dist-assert 4/4 pass.
- Source gates: a11y-lint 0, markdown-lint exit 0, simplicity-check PASS, zero em-dashes/banned words.
- Independent adversarial review (Opus) = ACCEPT; self-introspection clean.

Self-merged to `staging` per the documentation a11y-vpat lane policy. Production stays operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only content addition with no application logic, auth, or data handling changes.
> 
> **Overview**
> Adds a new **Accessibility statement** page under Pro → Miscellaneous → Terms & legals (`accessibility-statement.mdx`), delivering the docs-site ACR-style public statement for the a11y program.
> 
> The page states a **WCAG 2.2 Level AA** target, lists built-in accessibility behaviors, **discloses one known gap** (search results panel nesting/contrast, tied to upstream work), gives **support@tallyfy.com** for feedback, links to the corporate accessibility hub for VPAT requests, and includes a **Technical details** section on testing (axe, manual checks, browsers). It uses the same Starlight frontmatter and **Related articles** `CardGrid` pattern as sibling legal docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3481e7cd2a175763bc88b55b5b169cb98c1918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->