### PR TITLE
fix(ci): don't fail 'Generate IDs' when there are no ID changes to commit

### DIFF
--- a/.github/workflows/generate-ids.yml
+++ b/.github/workflows/generate-ids.yml
@@ -44,8 +44,12 @@ jobs:
             git config --local user.name "GitHub Action"
             git pull --no-rebase
             git add .
-            git commit -m "Push Articles With ID(s)" -a
-            git push
+            if git diff --cached --quiet; then
+              echo "No ID changes to commit (new files already had canonical IDs). Skipping commit so the pipeline can proceed."
+            else
+              git commit -m "Push Articles With ID(s)"
+              git push
+            fi
           else
             echo "No new files added. Skipping ID generation."
           fi


### PR DESCRIPTION
## Problem

The **Tallyfy Answers - Generate IDs** workflow fails whenever a newly-added `.mdx` file already carries its canonical `id` (= `MD5(content)`).

Sequence:
1. `generate-ids.py` sets `id = MD5(content)` — a **no-op** when the id already matches, so no file changes.
2. The "Commit and push" step then runs `git commit -m "..." -a`, which exits **code 1** with *"nothing to commit, working tree clean"*.
3. The step runs under `bash -e`, so that non-zero exit **fails the whole job**.

### Why it matters (not cosmetic)

`documentation-pipeline.yml` triggers on this workflow's completion and gates every job on `if: github.event.workflow_run.conclusion == 'success'`. So a failed Generate IDs **skips the entire indexing pipeline** — `upload-to-tallyfy-answers` never runs — and that push is **never indexed into Tallyfy Answers**.

**Confirmed repro:** PR #93 (`accessibility-statement.mdx`) shipped with a pre-baked `id: dd2531dd…`, so run [`27840807599`](https://github.com/tallyfy/documentation/actions/runs/27840807599) failed and the new page was not indexed into the staging Answers index.

## Fix

Guard the commit so the job only commits/pushes when there are actually staged changes:

```bash
git add .
if git diff --cached --quiet; then
  echo "No ID changes to commit ..."
else
  git commit -m "Push Articles With ID(s)"
  git push
fi
```

One file, no behavior change when IDs *do* need assigning.

## After merge (operational)

Re-run the pipeline (or push a no-op to `staging`) so the accessibility page and any other content skipped by the failed run gets indexed.

(Separately, `actions/checkout@v4` + `actions/setup-python@v4` now emit a Node 20 deprecation warning — minor, out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow guard with no runtime or auth impact; indexing behavior is unchanged when IDs need to be assigned.
> 
> **Overview**
> **Generate IDs** no longer fails when new `.mdx` files already have the correct frontmatter `id`, so the downstream documentation pipeline can still run.
> 
> The **Commit and push new articles with IDs** step now runs `git diff --cached --quiet` after `git add .` and only `git commit` / `git push` when there are staged changes; otherwise it logs and exits successfully. Commit no longer uses `-a`, so only staged ID updates are included.
> 
> When IDs are actually written, behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a6a6c92e6840b42c27155ae1a89d4cb4668de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->