### PR TITLE
Correct pricing page: AI not included on AppSumo lifetime deals

### DIFF
--- a/src/content/docs/pro/pricing/index.mdx
+++ b/src/content/docs/pro/pricing/index.mdx
@@ -46,7 +46,7 @@ Only give **Full Member** licenses to people who design workflows. Everyone else
 :::
 
 :::note[What's included for free?]
-All paid Tallyfy subscriptions include: unlimited guests, Single Sign-On (SSO), AI-powered workflow features, support consultations, and a 14-day trial. You can request a trial extension through [Tallyfy support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/). Sharing public templates is also free.
+All paid Tallyfy subscriptions include: unlimited guests, Single Sign-On (SSO), support consultations, and a 14-day trial. AI-powered workflow features are also included, except on AppSumo lifetime deals. You can request a trial extension through [Tallyfy support](/products/pro/miscellaneous/support/how-can-i-contact-tallyfys-support-team/). Sharing public templates is also free.
 :::
 
 ### Seat-based billing


### PR DESCRIPTION
## What

Corrects a now-false claim on the public pricing page. The "What's included for free?" note under Member tiers stated:

> All paid Tallyfy subscriptions include: unlimited guests, Single Sign-On (SSO), **AI-powered workflow features**, support consultations, and a 14-day trial.

AppSumo lifetime deals are paid subscriptions, so this blanket "all paid subscriptions" claim now misrepresents them.

## Why

As part of the AppSumo zero-AI change, generative AI has been turned off for every AppSumo lifetime org on production (`use_generative_ai = false`, set for ~2,309 active orgs). See the ops record on tallyfy/api-v2#9543. AI is no longer included for those paid subscriptions, so the universal claim is false for them.

Worth flagging: the api-v2 issue's own "Docs impact" section read "None public," but this specific public pricing statement was missed. This PR closes that gap.

## Change

Pulls "AI-powered workflow features" out of the universal list and names the exception, reusing the "AppSumo lifetime" wording already on the [seat-billing page](/products/pro/settings/billing/how-seat-billing-works/).

Before:
> All paid Tallyfy subscriptions include: unlimited guests, Single Sign-On (SSO), AI-powered workflow features, support consultations, and a 14-day trial.

After:
> All paid Tallyfy subscriptions include: unlimited guests, Single Sign-On (SSO), support consultations, and a 14-day trial. AI-powered workflow features are also included, except on AppSumo lifetime deals.

## Scope (deliberately untouched)

- The separate line about **AI-powered content localization (requires Azure integration)** stays as-is. That is a BYO-Azure translation feature, not a Tallyfy generative-AI feature, and it remains on (confirmed in tallyfy/client#18476).
- Related articles, `lastUpdated`, and `id` are auto-generated and untouched. The diff is a single line.

## Validation (local)

- `simplicity-check.py`: PASS, score 7.5 (threshold 45), no AI-tell words.
- `markdown-lint.py --dir src/content/docs`: exit 0, no errors.
- `validate-internal-links.py --dir src/content/docs`: all 3844 links valid.
- No em-dashes or en-dashes.

## Deploy note

Base is `staging`. Please do not merge to `main` here. Staging to production is the normal human promotion step.

Refs tallyfy/api-v2#9543, tallyfy/client#18476

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line public docs copy change with no product or billing logic impact.
> 
> **Overview**
> Updates the **What's included for free?** note on the Pro pricing page so it no longer claims every paid subscription includes AI-powered workflow features.
> 
> AI is listed as included in a separate sentence, with an explicit **except on AppSumo lifetime deals** carve-out, matching production where generative AI is disabled for those orgs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd4a42050d51dd1498466518832a0032d79331c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->