### PR TITLE
Document the full form-field value contract for prerun and taskdata

### DIFF
--- a/src/content/docs/pro/integrations/byo-ai/use-cases/launch-processes-with-pre-filled-data.mdx
+++ b/src/content/docs/pro/integrations/byo-ai/use-cases/launch-processes-with-pre-filled-data.mdx
@@ -171,11 +171,13 @@ The value format depends on the field type:
 | Date | An ISO 8601 string, like `"2026-03-15T00:00:00.000Z"` |
 | Radio button | The option's text as a plain string |
 | Dropdown | An object with both keys: `{ "id": 2, "text": "Enterprise" }` |
-| Checklist (multi-select) | A list of those objects |
-| Table | A list with one entry per column |
+| Checklist (multi-select) | A list of those objects, each carrying `"selected": true`: `[{ "id": 1, "text": "Laptop", "selected": true }]` |
+| Table | A list with one entry per column, in column order: `["Widget", "3"]` |
 | Assignees | `{ "users": [], "guests": [], "groups": [] }` |
 
-Dropdown and radio look alike in the app but take different shapes here. A radio takes the bare text, a dropdown needs the `id` and `text` pair together. See [Launch process](/products/pro/integrations/open-api/code-samples/processes/launch-process/) for the full endpoint reference.
+Dropdown and radio look alike in the app but take different shapes here. A radio takes the bare text, a dropdown needs the `id` and `text` pair together.
+
+Watch the multi-select shape in particular. Drop the `"selected": true` flag and the value still saves without an error, but it renders as empty text everywhere the field is used as a `{{variable}}`. Tell your AI to include the flag on every option it picks. See [Launch process](/products/pro/integrations/open-api/code-samples/processes/launch-process/) for the full endpoint reference.
 
 ## Related articles
 <CardGrid>

--- a/src/content/docs/pro/integrations/middleware/workato/how-to-launch-tallyfy-processes-from-workato.mdx
+++ b/src/content/docs/pro/integrations/middleware/workato/how-to-launch-tallyfy-processes-from-workato.mdx
@@ -193,11 +193,13 @@ The value format depends on what kind of field it is:
 | Date | An ISO 8601 string: `"2026-03-15T00:00:00.000Z"` |
 | Radio button | The option's text as a plain string: `"Full-time"` |
 | Dropdown | An object with both keys: `{ "id": 2, "text": "Engineering" }` |
-| Checklist (multi-select) | A list of those objects: `[{ "id": 1, "text": "Laptop" }]` |
-| Table | A list with one entry per column |
+| Checklist (multi-select) | A list of those objects, each carrying `"selected": true`: `[{ "id": 1, "text": "Laptop", "selected": true }]` |
+| Table | A list with one entry per column, in column order: `["Widget", "3"]` |
 | Assignees | `{ "users": [], "guests": [], "groups": [] }` |
 
 Dropdown and radio look alike in the app but take different shapes here. A radio takes the bare text, a dropdown needs the `id` and `text` pair.
+
+The multi-select shape needs one extra thing: `"selected": true` on every option you're picking. Leave it off and Tallyfy still accepts the recipe step without an error, but the field renders as empty text anywhere it's used as a `{{variable}}`.
 
 Here's an example with different field types:
 ```json

--- a/src/content/docs/pro/integrations/open-api/code-samples/processes/launch-process.mdx
+++ b/src/content/docs/pro/integrations/open-api/code-samples/processes/launch-process.mdx
@@ -70,7 +70,30 @@ The `prerun` object is keyed by **kick-off field timeline ID**. The value format
 - **Radio button:** `{ "field_id_ghi": "Selected Option Value" }`
 - **Dropdown:** `{ "field_id_jkl": { "id": 2, "text": "Option Text", "value": null } }`
 - **Checklist (multi-select):** `{ "field_id_mno": [{ "id": 1, "text": "Option 1", "value": null, "selected": true }] }`
+- **Table:** `{ "field_id_stu": ["Widget", "3"] }` (one entry per column, in the order the columns are defined)
+- **Assignees:** `{ "field_id_vwx": { "users": [12345], "guests": ["guest@example.com"], "groups": ["group_id"] } }`
 - **File/Image:** `{ "field_id_pqr": [{ "id": "asset_id", "filename": "report.pdf", "version": 1, "url": "...", "uploaded_from": "ko_field", "subject": { "id": "template_id", "type": "Checklist" } }] }` (requires pre-uploading the file first)
+
+:::caution[Multi-select needs `selected: true` on every chosen option]
+An option without `"selected": true` passes validation and gets stored, so the request still returns `201 Created`. But anywhere that field is used as a `{{variable}}`, the value renders as empty text. If a multi-select value shows up blank in a task description or an email, this is almost always why.
+:::
+
+#### Sending a table value
+
+A table value is a flat list with exactly one entry per column, in the order the columns are defined on the field. Send a different number of entries and the API rejects the whole request with `Number of columns does not match required columns`.
+
+For a table field with two columns, **Item** and **Qty**:
+
+```json
+{
+    "checklist_id": "template123",
+    "prerun": {
+        "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4": ["Widget", "3"]
+    }
+}
+```
+
+The first entry lands in the first column, the second in the second, and so on. To check the column order, call `GET /organizations/{org_id}/checklists/{checklist_id}` and read the `columns` array on that field inside the response's `prerun` array. That's the same response you use to look up the field's timeline ID.
 
 ### Overriding task properties with `tasks`
 

--- a/src/content/docs/pro/integrations/open-api/code-samples/tasks/update-task.mdx
+++ b/src/content/docs/pro/integrations/open-api/code-samples/tasks/update-task.mdx
@@ -52,15 +52,32 @@ For one-off tasks, `title`, `deadline`, and `owners` are **required** in every u
 
 ### Updating form fields with `taskdata`
 
-Include a `taskdata` object in the request body. Keys are **Form Field IDs (Capture IDs)**, and values depend on the field type:
+Include a `taskdata` object in the request body. Keys are **form field timeline IDs**, and values depend on the field type.
 
--   **Text/Textarea:** `{ "taskdata": { "field_id_abc": "New text value" } }`
--   **Date:** `{ "taskdata": { "field_id_def": "2025-12-31T23:59:59Z" } }`
--   **Radio Button:** `{ "taskdata": { "field_id_ghi": "Selected Value Text" } }`
--   **Dropdown:** `{ "taskdata": { "field_id_jkl": { "id": 3, "text": "Chosen Option Text", "value": null } } }` (Provide the selected option object)
--   **Multi-select Checkboxes:** `{ "taskdata": { "field_id_mno": [ { "id": 1, ..., "selected": true }, { "id": 2, ..., "selected": false }, { "id": 3, ..., "selected": true } ] } }` (Provide the full array of options with their selected status)
--   **File/Image:** See [Attach files using the API](https://tallyfy.com/products/pro/integrations/open-api/code-samples/files/upload-attach-file/) sample. Files must be uploaded first.
--   **Table:** Table fields may need specific formatting - check Swagger or contact Tallyfy support.
+`taskdata` and the `prerun` object used when [launching a process](/products/pro/integrations/open-api/code-samples/processes/launch-process/) run through the same validator, so the value shapes below are identical on both surfaces.
+
+| Field type | Value to send |
+|------------|---------------|
+| Short text | A plain string, max 200 characters |
+| Long text (textarea) | A plain string, max 30,000 characters |
+| Email | A plain string |
+| Date | An ISO 8601 string: `"2025-12-31T23:59:59Z"` |
+| Radio button | The option's text as a bare string: `"Full-time"` |
+| Dropdown | One object with both keys: `{ "id": 3, "text": "Office 365", "value": null }` |
+| Checklist (multi-select) | A list of those objects, each with `"selected"`: `[{ "id": 1, "text": "Slack", "selected": true }]` |
+| Table | A flat list with one entry per column, in column order: `["Widget", "3"]` |
+| Assignees | `{ "users": [12345], "guests": ["guest@example.com"], "groups": ["group_id"] }` |
+| File/Image | A list of file objects. See [Attach files using the API](/products/pro/integrations/open-api/code-samples/files/upload-attach-file/) - files must be uploaded first. |
+
+Three shapes catch people out:
+
+-   **Radio and dropdown look identical in the app but differ here.** A radio takes the bare option text. A dropdown needs the `id` and `text` pair together, and the `text` has to match the option exactly.
+-   **Every chosen multi-select option needs `"selected": true`.** Without it the value still saves and you still get a `200`, but the field renders as empty text wherever it's used as a `{{variable}}`. A blank multi-select in a task description or an email is nearly always a missing `selected` flag.
+-   **A table takes one entry per column, not per row.** Send a different number of entries and the request fails with `Number of columns does not match required columns`.
+
+:::caution[An unknown key fails silently]
+Tallyfy matches every `taskdata` key against the task's form field timeline IDs. A key that matches nothing is dropped without an error, so the request still returns `200 OK` with that field unchanged. If a value doesn't stick, check your keys before anything else.
+:::
 
 #### Multiple field types in one call
 


### PR DESCRIPTION
Closes three documentation gaps in the form-field value contract. Every shape below was verified against `api-v2` before writing; nothing here is inferred from prose.

## Gap 1: no worked `table` example existed anywhere

`update-task.mdx:63` literally said *"Table fields may need specific formatting - check Swagger or contact Tallyfy support."* `launch-process.mdx` omitted `table` from the prerun list entirely.

The contract is precise and three independent sources agree:

- `api-v2/app/Http/Requests/Captures/FormValuesValidator.php:96-104` rejects anything where `count($values) !== count($capture->columns)` with `Number of columns does not match required columns`
- `migrator/shared/prerun_encoder.py::_encode_table` documents *"The API requires a list with exactly one entry per defined column"*, and `migrator/shared/tests/test_prerun_encoder.py::TestTable` asserts `["Widget", "3"]` for a two-column field
- `n8n/nodes/Tallyfy/Tallyfy.node.ts:1329` describes an array whose length equals the column count

Added a worked example under a new `#### Sending a table value` heading in `launch-process.mdx`, plus a `Table` row in both per-type lists.

## Gap 2: two derived tables dropped `"selected": true`

Both tables were derived from `launch-process.mdx` but lost the flag. The Workato page was the worse of the two because it shipped a concrete copy-pasteable value missing it:

```
| Checklist (multi-select) | A list of those objects: `[{ "id": 1, "text": "Laptop" }]` |
```

That payload passes validation and stores fine, so the caller gets a success response. But `api-v2/app/Traits/VariableReplacement.php:266-276` only emits options where `data_get($option, 'selected')` is truthy, so every `{{variable}}` rendering of the field produces an empty string. Silent failure.

Fixed in both `launch-processes-with-pre-filled-data.mdx` and `how-to-launch-tallyfy-processes-from-workato.mdx`, and each now explains the consequence rather than just showing the shape.

## Gap 3: `taskdata` had no per-type shape documentation

`taskdata` runs through the same validator as `prerun` (`TaskRequestValidator.php:38` calls `FormValuesValidator::validateFormField`), but the docs treated them as unrelated surfaces with divergent coverage. `update-task.mdx` now carries a full per-type table, including the `table` and `assignees` shapes it never had.

Two accuracy fixes came out of the same read:

- Keys are **form field timeline IDs**, not "Capture IDs" as the page claimed. `TaskRequestValidator.php:31` matches on `->where('timeline_id', $captureTimelineId)`.
- An unmatched key is dropped silently with a `200`. `TaskRequestValidator.php:33-35` does `if (is_null($capture)) { continue; }`, and `Task::updateCaptureValues` (`app/Models/Task.php:1648`) only iterates fields whose `timeline_id` matched, so the value is never written. This mirrors the `prerun` trap already documented on `via-api.mdx`, which was undocumented here.

## Verification

- `python3 scripts/validate-internal-links.py --dir src/content/docs` - all 3,966 links valid across 742 files
- `python3 scripts/markdown-lint.py --dir src/content/docs` - exit 0
- `python3 scripts/simplicity-check.py` on the two business-facing pages - both PASS (score 2.3 and 12.8, threshold 45)
- Zero em-dashes and zero blacklisted words across all four files
- No pipeline-generated fields touched: no `id`, `lastUpdated`, or `description` changes, and zero `LinkTitleCard` lines in the diff (the CRLF line endings the generator writes into the Related-articles block were preserved byte-for-byte)

Staging only. Not merged to `main` - production promotion is a human gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX; no application code, auth, or data paths are modified.
> 
> **Overview**
> Aligns integration docs so **`prerun`** (launch) and **`taskdata`** (task update) describe the same per-type payloads, backed by the shared API validator.
> 
> **`launch-process.mdx`** now documents **table** and **assignees** shapes, adds a worked table example and column-count error behavior, and calls out that multi-select options need **`"selected": true`** or `{{variable}}` renders empty despite `201 Created`.
> 
> **`update-task.mdx`** replaces the old “check Swagger” table note with a full type table, states keys are **form field timeline IDs** (not “Capture IDs”), links shapes to launch **`prerun`**, and warns that unknown **`taskdata`** keys are dropped with **`200 OK`**.
> 
> **BYO AI** and **Workato** kick-off field tables are corrected for checklist (**`selected: true`**) and table (**column-order array**) examples, with short notes on the silent multi-select failure mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6340386e3d680e3fb26d8d155a0c751a3c5d553c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->