### PR TITLE
Add .github/CODEOWNERS so PRs get an automatic reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for every path in this repo.
+# Decided 2026-08-03; mirrored in the reviewer table in the GitHub-root CLAUDE.md.
+*  @amitkoth


### PR DESCRIPTION
## In plain English

**What this fixes:** PRs in this repo were opening with nobody assigned to review them, because the repo had no CODEOWNERS file. People had to guess who to ask, so PRs sat waiting.

**What it does:** Adds a two-line `.github/CODEOWNERS` naming @amitkoth as the default reviewer for every file in the repo. GitHub then requests their review automatically on every new PR.

**Why this way:** A CODEOWNERS file is enforced by GitHub itself, so it keeps working with no one having to remember it. Writing the same convention only into a documentation file relies on whoever opens the PR having read that file.

**How we got here:** A sweep on 2026-08-03 checked every active Tallyfy repo and found nine with no CODEOWNERS at all. The owner picked the reviewers repo by repo. The same table is now recorded in the GitHub-root CLAUDE.md so sessions stop guessing.

## Changes

- `.github/CODEOWNERS` (new): `*  @amitkoth`

## Verification

```bash
gh api repos/tallyfy/documentation/codeowners/errors --jq '.errors | length'   # expect 0
```

An empty `errors` array is the authoritative check: it is what catches a mistyped or non-member handle, which reading the file locally cannot.

Fixes #113