### PR TITLE
Make the staging to main promotion path actually hold: a path-based gate, plus two defects it uncovered

### DIFF
--- a/.github/promotion-holds.txt
+++ b/.github/promotion-holds.txt
@@ -1,0 +1,70 @@
+# Promotion hold list
+#
+# WHAT THIS IS
+# Paths listed here must NOT reach production. Production is the `main` branch, and
+# `main` is reached only by a deliberate `staging` -> `main` merge (a "promotion").
+# While a path is held, any promotion whose tree contains a file matching it FAILS.
+#
+# WHY IT EXISTS
+# Nine pages telling customers to configure SSO at Settings > Organization > Security > SSO
+# went live on 2026-06-18 and stayed live for seven weeks while that screen did not exist in
+# production. There was supposed to be a gate. The gate was a sentence in a GitHub issue, and
+# a sentence in an issue cannot stop a merge. See tallyfy/documentation#88 and #118.
+#
+# HOW A HOLD IS EVALUATED
+# The check is PRESENCE-based, not diff-based: it fails if the promoted tree CONTAINS a
+# matching file, regardless of whether this particular promotion changed it. This is
+# deliberate. Promotions here are fast-forwards (`main` is an ancestor of `staging`), and the
+# `workflow_run` event that drives the pipeline carries no "previous main tip", so a
+# diff-based check would have no reliable base and would fail toward green - passing when it
+# could not compute an answer. Presence fails closed.
+#
+# FORMAT - one hold per line, three whitespace-separated fields:
+#
+#   <id>  <glob>  <reason, free text to end of line>
+#
+#   id      lowercase letters, digits and hyphens. Names the hold so an override must be
+#           specific. Must be unique in this file.
+#   glob    a repo-relative path pattern, fnmatch style. `*` matches ANY character INCLUDING
+#           `/`, so `src/content/docs/pro/*sso*` matches at any depth. `?` matches one
+#           character, `[abc]` a set.
+#   reason  why this is held and what lifts it. Required, and it must be a real sentence -
+#           the checker rejects a reason under 10 characters.
+#
+# A line that does not parse is a HARD FAILURE, not a skipped line. A hold that silently
+# fails to parse is exactly the gate-that-cannot-fire this file exists to prevent.
+# A missing or unreadable file is also a hard failure, so the mechanism cannot be removed
+# quietly.
+#
+# RELEASING A HOLD
+# 1. NORMAL - delete its line here and promote. That is a reviewable diff with an author and
+#    a date, which is the whole point of holding the list as data rather than as prose.
+# 2. ONE PROMOTION ONLY - put `[release-hold: <id>]` in the promotion's head commit message.
+#    It names one id, so it cannot blanket-release the file, it applies to that promotion
+#    alone, and it stays in `main`'s history forever. A plain `git merge staging` FAST-
+#    FORWARDS and carries no message of yours, so this needs an explicit merge commit:
+#
+#      git checkout main && git pull
+#      git merge --no-ff staging -m "Promote staging to main [release-hold: sso-screens] <why>"
+#      git push origin main
+#
+# WHAT THIS GATE DOES NOT COVER
+# The pipeline is triggered by `generate-ids.yml`, whose `paths:` filter excludes
+# `src/content/docs/pro/changelog/**`. A promotion touching only changelog paths starts no
+# pipeline, so a hold on a changelog path would never be evaluated. It would also publish
+# nothing, because the `sync` job that copies content to support-docs would not run either.
+# Do not put a changelog path on hold and expect it to be enforced.
+#
+# Checker: scripts/promotion-hold-check.py (run it locally with --self-test).
+#
+# ---------------------------------------------------------------------------------------
+# ACTIVE HOLDS - none.
+#
+# Deliberately empty. The nine SSO pages are NOT seeded here: an owner decision on
+# 2026-08-08 accepted the published state and re-scoped rather than unpublishing them, and
+# that decision is not being reopened by building this control (#118).
+#
+# Example of what an entry looks like, kept commented out so the file is never ambiguous
+# about whether something is held:
+#
+# sso-screens  src/content/docs/pro/*sso*  Screen not in production yet. Lift when Settings > Organization > Security > SSO ships.

--- a/.github/workflows/documentation-pipeline.yml
+++ b/.github/workflows/documentation-pipeline.yml
@@ -18,6 +18,51 @@ on:
 
 
 jobs:
+  # Blocks a staging -> main promotion that carries a path on hold (see #118, successor to
+  # #88). A root job on purpose: nothing upstream can skip it. It is listed in the `needs` of
+  # every job that can publish, because a red gate that does not stop the publish is
+  # decoration - that wiring is itself asserted by the --check-wiring step below.
+  #
+  # NOTE on SHAs: on a workflow_run event `github.sha` is the head of the DEFAULT branch
+  # (staging), not the commit that triggered the run. Measured on two real promotions:
+  # run 30914229312 reported sha=92156c924 for a push of 0c8011844 to main, and run
+  # 30619407542 reported c25ac48ea for a push of 44fbbdbe5. So the promoted commit is
+  # workflow_run.head_sha, and the job re-verifies it is on origin/main before trusting it.
+  promotion-hold-gate:
+    # Deliberately NO `if:` and NO `needs:`, so this job can never be skipped.
+    # Measured on run 27840821129: when the triggering run does not succeed, every
+    # `if: conclusion == 'success'` job skips, and `sync` STILL RUNS - its
+    # `if: !failure() && !cancelled()` is a status-function conditional, which overrides the
+    # default "skip when a needed job was skipped". A gate carrying that same `if:` would
+    # therefore be skipped on exactly the runs where `sync` publishes unchecked. A gate that
+    # can be skipped is not a gate, so this one always runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0   # merge-base --is-ancestor needs real history
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Prove the gate can fail (red and green control)
+        run: python scripts/promotion-hold-check.py --self-test
+        shell: bash
+      - name: Prove the gate is still wired to the publishing jobs
+        run: |
+          python -m pip install --upgrade pyyaml
+          python scripts/promotion-hold-check.py --check-wiring
+        shell: bash
+      - name: Check the promotion against the hold list
+        # Values go through env, never straight into the shell line: workflow_run is a
+        # privileged trigger and its payload is attacker-influenced input.
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          python scripts/promotion-hold-check.py --commit "$HEAD_SHA" --branch "$HEAD_BRANCH"
+        shell: bash
+
   validate-markdown:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
@@ -88,7 +133,9 @@ jobs:
       generate-snippets-completed: ${{ steps.generate-snippets.outcome }}
 
   upload-to-tallyfy-answers:
-    needs: generate-snippets
+    # promotion-hold-gate: on main this uploads to the PRODUCTION Answers index, so held
+    # content must not reach it either.
+    needs: [generate-snippets, promotion-hold-gate]
 #    needs: validate-markdown
     runs-on: ubuntu-latest
     steps:
@@ -215,7 +262,10 @@ jobs:
           fi
 
   sync:
-    needs: [ validate-markdown, upload-to-tallyfy-answers, check-deleted-files, update-last-modified, generate-related-articles ]
+    # promotion-hold-gate is load-bearing here: this job is what actually publishes, by
+    # rsyncing into support-docs `production`. `if: !failure()` only considers jobs in
+    # `needs`, so a gate left out of this list would go red while the content shipped anyway.
+    needs: [ promotion-hold-gate, validate-markdown, upload-to-tallyfy-answers, check-deleted-files, update-last-modified, generate-related-articles ]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/documentation-pipeline.yml
+++ b/.github/workflows/documentation-pipeline.yml
@@ -102,7 +102,7 @@ jobs:
             echo "Skipping snippet generation on main — staging owns auto-regen (see #56). Files inherit from staging via merge."
             exit 0
           fi
-          file_changes=$(git diff-tree --no-commit-id --name-only --diff-filter=A -r ${{ github.sha }} | grep '\.mdx$' || true )
+          file_changes=$(git diff-tree --no-commit-id --name-only --diff-filter=A -r ${{ github.event.workflow_run.head_sha }} | grep '\.mdx$' || true )
           if [[ -n "$file_changes" ]]; then
             git pull
             python -m pip install --upgrade python-frontmatter requests
@@ -114,7 +114,7 @@ jobs:
       - name: Commit and push articles with snippets
         if: ${{ github.event.workflow_run.head_branch != 'main' }}
         run: |
-          file_changes=$(git diff-tree --no-commit-id --name-only --diff-filter=A -r ${{ github.sha }} | grep '\.mdx$' || true )
+          file_changes=$(git diff-tree --no-commit-id --name-only --diff-filter=A -r ${{ github.event.workflow_run.head_sha }} | grep '\.mdx$' || true )
           if [[ -n "$file_changes" ]]; then
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
@@ -171,19 +171,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          ref: ${{ github.event.workflow_run.head_branch }}
+          # The exact promoted commit, not the branch tip: this job diffs that commit, and a
+          # commit missing from a depth-2 checkout makes `git diff-tree` fail, which the
+          # `|| true` below would otherwise launder into "nothing was deleted".
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Check deleted files
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          file_changes=$(git diff-tree --no-commit-id --name-only --diff-filter=D -r ${{ github.sha }} | grep '\.mdx$' || true )
+          # Split the two exit codes apart. `git diff-tree` failing means we do not know what
+          # was deleted, and must not proceed as though nothing was; `grep` finding no .mdx
+          # legitimately means nothing was deleted. One `|| true` over the whole pipeline
+          # cannot tell those apart, and answers "nothing" to both.
+          deleted=$(git diff-tree --no-commit-id --name-only --diff-filter=D -r "$HEAD_SHA")
+          file_changes=$(printf '%s\n' "$deleted" | grep '\.mdx$' || true )
           if [[ -n "$file_changes" ]]; then
             python -m pip install --upgrade python-frontmatter requests
             if [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
-              python scripts/check-deleted-files.py --commit_sha=${{ github.sha }} --collection_name=tyfy --github_token=${{ secrets.GH_TOKEN }} --answers_api_key=${{ secrets.ANSWERS_API_KEY }} --base_url https://answers.tallyfy.com
+              python scripts/check-deleted-files.py --commit_sha=${{ github.event.workflow_run.head_sha }} --collection_name=tyfy --github_token=${{ secrets.GH_TOKEN }} --answers_api_key=${{ secrets.ANSWERS_API_KEY }} --base_url https://answers.tallyfy.com
             else
-              python scripts/check-deleted-files.py --commit_sha=${{ github.sha }} --collection_name=tyfy --github_token=${{ secrets.GH_TOKEN }} --answers_api_key=${{ secrets.ANSWERS_API_KEY }} --base_url https://staging.answers.tallyfy.com
+              python scripts/check-deleted-files.py --commit_sha=${{ github.event.workflow_run.head_sha }} --collection_name=tyfy --github_token=${{ secrets.GH_TOKEN }} --answers_api_key=${{ secrets.ANSWERS_API_KEY }} --base_url https://staging.answers.tallyfy.com
             fi
           else
             echo "No files were deleted. Skipping ..."
@@ -266,7 +276,12 @@ jobs:
     # rsyncing into support-docs `production`. `if: !failure()` only considers jobs in
     # `needs`, so a gate left out of this list would go red while the content shipped anyway.
     needs: [ promotion-hold-gate, validate-markdown, upload-to-tallyfy-answers, check-deleted-files, update-last-modified, generate-related-articles ]
-    if: ${{ !failure() && !cancelled() }}
+    # The `conclusion == 'success'` term is load-bearing and is asserted by --check-wiring.
+    # `!failure() && !cancelled()` alone is a status-function conditional, which replaces the
+    # default "skip when a needed job was skipped". Neither term is true when the needs were
+    # merely SKIPPED, so this job used to publish on runs where every validation job skipped.
+    # Measured on run 27840821129: all six other jobs `skipped`, sync `success`. See #122.
+    if: ${{ !failure() && !cancelled() && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository (tallyfy/documentation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -804,6 +804,7 @@ The `documentation-pipeline.yml` runs on pushes to `staging` and `main`, but aut
 |---|---|---|---|---|
 | `generate-ids.yml` | staging only (new files arrive via merge to main) | New files only (`diff-filter=A`) | Adds `id` field to frontmatter | No - auto-assigned on creation |
 | `validate-markdown` | both branches | Every push | Nothing — just validates | N/A |
+| `promotion-hold-gate` | both branches (self-tests everywhere, enforces on `main`) | Every push | Nothing - it blocks the promotion when the tree carries a path listed in `.github/promotion-holds.txt` | N/A - edit the hold list, see "Holding a path back from production" below |
 | `generate-snippets` | **staging only** | New files only (`diff-filter=A`) | Sets `description` field | **Yes** - only overwrites new files, not modified ones |
 | `upload-to-tallyfy-answers` | both branches | Every push (staging → staging Answers, main → prod Answers for prod search) | Nothing in files (uploads to Answers API) | N/A |
 | `check-deleted-files` | main only | Every push (cleans deleted articles from prod Answers) | Nothing in files | N/A |
@@ -1357,6 +1358,28 @@ git push origin main
 # 6. Return to staging
 git checkout staging
 ```
+
+**Holding a path back from production (`.github/promotion-holds.txt`):**
+
+Sometimes content is ready to write but not ready to publish, usually because the screen it
+describes isn't in production yet. Put the path on hold instead of relying on someone
+remembering. Nine SSO pages went live on 2026-06-18 and stayed live for seven weeks against a
+screen that didn't exist, because the only thing holding them back was a sentence in a GitHub
+issue (#88, #118).
+
+- Add a line to `.github/promotion-holds.txt`: `<id>  <glob>  <reason>`. The `promotion-hold-gate`
+  job then fails any promotion whose tree contains a matching file, before `sync` can copy
+  anything to support-docs.
+- The check is presence-based, not diff-based - it fails if the promoted tree *contains* the
+  path, whether or not this promotion changed it. Promotions here fast-forward and the
+  `workflow_run` event carries no previous-main SHA, so a diff-based check would have no base
+  and would pass when it couldn't compute an answer.
+- Release a hold by deleting its line (a reviewable diff), or for one promotion only by naming
+  it in the merge commit: `git merge --no-ff staging -m "Promote staging to main [release-hold: <id>] <why>"`.
+  A plain `git merge` fast-forwards and carries no message of yours, so the marker needs `--no-ff`.
+- Check it locally before pushing: `python3 scripts/promotion-hold-check.py --self-test`. The
+  same self-test runs in CI on every promotion, so the gate proves it can go red rather than
+  only ever being seen passing.
 
 **Verifying deployment:**
 - Staging: `curl -s https://staging.tallyfy.com/products/pro/ | head -50`

--- a/scripts/promotion-hold-check.py
+++ b/scripts/promotion-hold-check.py
@@ -396,6 +396,8 @@ def _error_kind(fn, *args):
 
 
 GATE_JOB = "promotion-hold-gate"
+PUBLISH_JOB = "sync"
+UPSTREAM_SUCCESS_TERM = "github.event.workflow_run.conclusion == 'success'"
 # Jobs that may legitimately run without waiting for the gate, each with the reason it is
 # harmless. Anything NOT listed here must depend on the gate, so adding a job forces a
 # decision instead of silently escaping the gate. Derived from the workflow file itself, so
@@ -443,6 +445,22 @@ def check_wiring(workflow_path):
         return GATE_JOB in needs_of(name)
 
     problems = []
+
+    # `sync` is the job that actually publishes, and it guards itself with a status-function
+    # conditional (`!failure() && !cancelled()`), which replaces the default "skip when a
+    # needed job was skipped". Without an explicit upstream-success term it therefore
+    # publishes on runs where every validation job skipped - measured on run 27840821129,
+    # where all six other jobs read `skipped` and `sync` read `success` (#122). That term
+    # cannot be observed locally, because it needs a real failed upstream run, so it is
+    # asserted statically here instead and this assertion has a control in both directions.
+    sync_if = str((jobs.get(PUBLISH_JOB) or {}).get("if", ""))
+    if PUBLISH_JOB in jobs and UPSTREAM_SUCCESS_TERM not in sync_if.replace('"', "'"):
+        problems.append(
+            f"job {PUBLISH_JOB!r} does not require {UPSTREAM_SUCCESS_TERM!r} in its `if`, so "
+            f"it will publish on runs where every validation job was skipped (see #122). "
+            f"Its condition is currently: {sync_if!r}"
+        )
+
     for name in jobs:
         if name in WIRING_EXEMPT:
             continue

--- a/scripts/promotion-hold-check.py
+++ b/scripts/promotion-hold-check.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Fail a staging -> main promotion that carries a held path.
+
+Background: tallyfy/documentation#88 asked for exactly this and said so itself - "only a
+path-based CI check on promotions to main would actually hold". #118 is the issue that built
+it. Nine SSO pages published for seven weeks against a screen that did not exist, because the
+only thing holding them back was a sentence in an issue.
+
+Three modes, all used by the `promotion-hold-gate` job in documentation-pipeline.yml:
+
+  --self-test     Build throwaway git repositories and prove the checker goes RED on a held
+                  path and GREEN once that path is gone. Runs on every invocation in CI, so
+                  the gate's ability to fail is asserted on every promotion rather than
+                  assumed. A check only ever seen passing is indistinguishable from one that
+                  cannot fail.
+  --check-wiring  Prove the gate is still wired into the jobs that publish. A red gate that
+                  does not block `sync` is decoration.
+  (default)       The check itself, against a promoted commit.
+
+Exit codes: 0 pass, 1 a hold was violated (or a self-test/wiring assertion failed), 2 the
+checker could not run - a broken checker is never a pass.
+"""
+
+import argparse
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HOLD_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+MIN_REASON_CHARS = 10
+# `[release-hold: <id>]` naming ONE hold. Deliberately not a bare keyword: a marker that
+# releases everything would get typed by muscle memory, and a keyword that matches anywhere
+# in free text fires from inside a sentence that meant the opposite.
+RELEASE_RE = re.compile(r"\[release-hold:\s*([a-z0-9][a-z0-9-]*)\s*\]")
+
+
+class CheckerError(Exception):
+    """The checker could not answer. Never treated as a pass."""
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def annotate(level, msg):
+    """GitHub Actions annotation, so a failure is visible in the run summary, not just logs."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::{level}::{msg}", flush=True)
+
+
+def git(repo, *args):
+    proc = subprocess.run(
+        ["git", "-C", repo, *args], capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        raise CheckerError(
+            f"git {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}"
+        )
+    return proc.stdout
+
+
+# --------------------------------------------------------------------------------------
+# hold list
+
+
+class Hold:
+    def __init__(self, hold_id, glob, reason, line_no):
+        self.id = hold_id
+        self.glob = glob
+        self.reason = reason
+        self.line_no = line_no
+
+
+def parse_holds(path):
+    """Parse the hold list. Any malformed line is fatal.
+
+    A hold that silently fails to parse is the exact failure this whole control exists to
+    prevent, so there is no lenient path here and no skipping.
+    """
+    if not os.path.isfile(path):
+        raise CheckerError(
+            f"hold list not found at {path}. The list is required even when it holds "
+            f"nothing - a missing list must be loud, not silently permissive."
+        )
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        raise CheckerError(f"cannot read hold list at {path}: {exc}")
+
+    holds = []
+    seen = {}
+    for line_no, line in enumerate(raw.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split(None, 2)
+        if len(parts) < 3:
+            raise CheckerError(
+                f"{path}:{line_no}: expected three fields '<id> <glob> <reason>', got "
+                f"{len(parts)}: {stripped!r}"
+            )
+        hold_id, glob, reason = parts[0], parts[1], parts[2].strip()
+        if not HOLD_ID_RE.match(hold_id):
+            raise CheckerError(
+                f"{path}:{line_no}: id {hold_id!r} must be lowercase letters, digits and "
+                f"hyphens"
+            )
+        if hold_id in seen:
+            raise CheckerError(
+                f"{path}:{line_no}: duplicate id {hold_id!r}, already defined on line "
+                f"{seen[hold_id]}. An override names one id, so ids must be unique."
+            )
+        if len(reason) < MIN_REASON_CHARS:
+            raise CheckerError(
+                f"{path}:{line_no}: hold {hold_id!r} needs a real reason beside it "
+                f"(at least {MIN_REASON_CHARS} characters), got {reason!r}"
+            )
+        seen[hold_id] = line_no
+        holds.append(Hold(hold_id, glob, reason, line_no))
+    return holds
+
+
+def matching_paths(holds, tracked_paths):
+    """Map each hold to the tracked files it matches. fnmatch `*` spans `/` by design."""
+    hits = {}
+    for hold in holds:
+        matched = [p for p in tracked_paths if fnmatch.fnmatchcase(p, hold.glob)]
+        if matched:
+            hits[hold.id] = (hold, sorted(matched))
+    return hits
+
+
+def released_ids(commit_message):
+    return set(RELEASE_RE.findall(commit_message or ""))
+
+
+# --------------------------------------------------------------------------------------
+# the check
+
+
+def check(repo, commit, holds_path, branch, require_on_branch=True):
+    """Return 0 to pass, 1 to fail. Raises CheckerError when it cannot answer."""
+    holds = parse_holds(holds_path)
+    log(f"Hold list {holds_path}: {len(holds)} active hold(s).")
+    for hold in holds:
+        log(f"  - {hold.id}: {hold.glob}  ({hold.reason})")
+
+    if branch != "main":
+        log(
+            f"Branch is {branch!r}, not 'main'. Holds are enforced on promotions to "
+            f"production only, so nothing to enforce here."
+        )
+        return 0
+
+    # Assert the commit really is on main before trusting the tree. A probe that takes a
+    # name and hands back an object must confirm the object is the one it was asked for -
+    # otherwise the gate could pass on a tree that was never promoted.
+    if require_on_branch:
+        proc = subprocess.run(
+            ["git", "-C", repo, "merge-base", "--is-ancestor", commit, "origin/main"],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            raise CheckerError(
+                f"{commit} is not an ancestor of origin/main (rc={proc.returncode}). "
+                f"Refusing to pass on a tree that cannot be shown to be the promoted one. "
+                f"{proc.stderr.strip()}"
+            )
+        log(f"Verified {commit[:9]} is on origin/main.")
+
+    tracked = [p for p in git(repo, "ls-tree", "-r", "--name-only", commit).splitlines() if p]
+    if not tracked:
+        raise CheckerError(
+            f"{commit} lists zero tracked files. A hold check over an empty file set passes "
+            f"every assertion made about it and proves nothing."
+        )
+    log(f"Promoted tree {commit[:9]}: {len(tracked)} tracked path(s).")
+
+    if not holds:
+        log("No active holds. Nothing can be violated.")
+        return 0
+
+    hits = matching_paths(holds, tracked)
+    if not hits:
+        log("PASS: the promoted tree contains no held path.")
+        return 0
+
+    message = git(repo, "log", "-1", "--format=%B", commit)
+    released = released_ids(message)
+
+    violations = []
+    for hold_id, (hold, files) in sorted(hits.items()):
+        if hold_id in released:
+            log("")
+            log(f"RELEASED: hold {hold_id!r} released by this promotion's commit message.")
+            log(f"  reason on file : {hold.reason}")
+            log(f"  files it covers: {len(files)}")
+            for path in files[:20]:
+                log(f"    {path}")
+            if len(files) > 20:
+                log(f"    ... and {len(files) - 20} more (not truncated silently: {len(files)} total)")
+            annotate(
+                "warning",
+                f"Promotion hold {hold_id} was deliberately released by the commit message. "
+                f"{len(files)} held file(s) are being published.",
+            )
+        else:
+            violations.append((hold, files))
+
+    unknown = released - {h.id for h in holds}
+    for ghost in sorted(unknown):
+        annotate(
+            "warning",
+            f"Commit message releases hold {ghost!r}, which is not in the hold list. "
+            f"Nothing was released by it.",
+        )
+
+    if not violations:
+        log("")
+        log("PASS: every matched hold was deliberately released by this promotion.")
+        return 0
+
+    log("")
+    log("FAIL: this promotion carries paths that are on hold.")
+    for hold, files in violations:
+        log("")
+        log(f"  hold   : {hold.id}   ({holds_path}:{hold.line_no})")
+        log(f"  pattern: {hold.glob}")
+        log(f"  reason : {hold.reason}")
+        log(f"  matched: {len(files)} file(s)")
+        for path in files[:20]:
+            log(f"    {path}")
+        if len(files) > 20:
+            log(f"    ... and {len(files) - 20} more (not truncated silently: {len(files)} total)")
+        annotate(
+            "error",
+            f"Promotion blocked by hold '{hold.id}': {len(files)} held file(s) present. "
+            f"{hold.reason}",
+        )
+    log("")
+    log("To proceed, either delete the hold from the list (a reviewable diff), or release it")
+    log("for this promotion only:")
+    log("  git merge --no-ff staging -m \"Promote staging to main [release-hold: <id>] <why>\"")
+    return 1
+
+
+# --------------------------------------------------------------------------------------
+# self-test: the red/green control, run on every invocation
+
+
+def _build_fixture(tmp, files, hold_lines, commit_message="fixture commit"):
+    repo = os.path.join(tmp, "repo")
+    os.makedirs(repo, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+    subprocess.run(["git", "-C", repo, "config", "user.email", "t@example.com"], check=True)
+    subprocess.run(["git", "-C", repo, "config", "user.name", "Fixture"], check=True)
+    for rel in files:
+        path = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("fixture\n")
+    subprocess.run(["git", "-C", repo, "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", repo, "commit", "-q", "-m", commit_message], check=True
+    )
+    holds_path = os.path.join(tmp, "holds.txt")
+    with open(holds_path, "w", encoding="utf-8") as fh:
+        fh.write("# fixture hold list\n" + "\n".join(hold_lines) + "\n")
+    sha = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    return repo, sha, holds_path
+
+
+HELD_PAGE = "src/content/docs/pro/settings/how-to-configure-sso.mdx"
+OTHER_PAGE = "src/content/docs/pro/tracking-and-tasks/tasks/index.mdx"
+FIXTURE_HOLD = "sso-screens  src/content/docs/pro/*sso*  Screen not in production yet."
+
+
+def self_test():
+    """Prove the checker fails on a held path and passes without it. Both directions.
+
+    Neither half means anything alone. A red-only control cannot distinguish a working gate
+    from one that fails on everything; a green-only control cannot distinguish a working gate
+    from one that cannot fail.
+    """
+    cases = []
+
+    def case(name, expected, fn):
+        try:
+            actual = fn()
+        except CheckerError as exc:
+            actual = f"CheckerError: {exc}"
+        ok = actual == expected
+        cases.append((name, expected, actual, ok))
+        log(f"  [{'ok' if ok else 'FAILED'}] {name}: expected {expected!r}, got {actual!r}")
+
+    with tempfile.TemporaryDirectory() as tmp_red:
+        repo, sha, holds = _build_fixture(
+            tmp_red, [HELD_PAGE, OTHER_PAGE], [FIXTURE_HOLD]
+        )
+        case(
+            "RED - promotion carrying a held path is blocked",
+            1,
+            lambda: check(repo, sha, holds, "main", require_on_branch=False),
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_green:
+        repo, sha, holds = _build_fixture(tmp_green, [OTHER_PAGE], [FIXTURE_HOLD])
+        case(
+            "GREEN - same promotion with the held path removed passes",
+            0,
+            lambda: check(repo, sha, holds, "main", require_on_branch=False),
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_rel:
+        repo, sha, holds = _build_fixture(
+            tmp_rel,
+            [HELD_PAGE, OTHER_PAGE],
+            [FIXTURE_HOLD],
+            commit_message="Promote staging to main [release-hold: sso-screens] shipping now",
+        )
+        case(
+            "RELEASE - a commit message naming the hold releases it",
+            0,
+            lambda: check(repo, sha, holds, "main", require_on_branch=False),
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_wrong:
+        repo, sha, holds = _build_fixture(
+            tmp_wrong,
+            [HELD_PAGE, OTHER_PAGE],
+            [FIXTURE_HOLD],
+            commit_message="Promote staging to main [release-hold: some-other-hold]",
+        )
+        case(
+            "RELEASE is specific - naming a different hold releases nothing",
+            1,
+            lambda: check(repo, sha, holds, "main", require_on_branch=False),
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_staging:
+        repo, sha, holds = _build_fixture(
+            tmp_staging, [HELD_PAGE, OTHER_PAGE], [FIXTURE_HOLD]
+        )
+        case(
+            "SCOPE - the same held tree on staging is not blocked",
+            0,
+            lambda: check(repo, sha, holds, "staging", require_on_branch=False),
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_bad:
+        repo, sha, _ = _build_fixture(tmp_bad, [OTHER_PAGE], [])
+        bad = os.path.join(tmp_bad, "malformed.txt")
+        with open(bad, "w", encoding="utf-8") as fh:
+            fh.write("sso-screens src/content/docs/pro/*sso*\n")  # no reason
+        case(
+            "FAIL CLOSED - a malformed hold line is fatal, never skipped",
+            "CheckerError",
+            lambda: _error_kind(check, repo, sha, bad, "main"),
+        )
+        case(
+            "FAIL CLOSED - a missing hold list is fatal",
+            "CheckerError",
+            lambda: _error_kind(
+                check, repo, sha, os.path.join(tmp_bad, "nope.txt"), "main"
+            ),
+        )
+
+    failed = [c for c in cases if not c[3]]
+    log("")
+    if failed:
+        annotate("error", f"promotion-hold-check self-test FAILED ({len(failed)} case(s))")
+        log(f"SELF-TEST FAILED: {len(failed)} of {len(cases)} case(s).")
+        return 1
+    log(f"SELF-TEST PASSED: {len(cases)} of {len(cases)} case(s), red and green both proven.")
+    return 0
+
+
+def _error_kind(fn, *args):
+    try:
+        fn(*args)
+    except CheckerError:
+        return "CheckerError"
+    return "no error"
+
+
+# --------------------------------------------------------------------------------------
+# wiring guard: a red gate that blocks nothing is decoration
+
+
+GATE_JOB = "promotion-hold-gate"
+# Jobs that may legitimately run without waiting for the gate, each with the reason it is
+# harmless. Anything NOT listed here must depend on the gate, so adding a job forces a
+# decision instead of silently escaping the gate. Derived from the workflow file itself, so
+# it grows with the file rather than freezing at today's job list.
+WIRING_EXEMPT = {
+    GATE_JOB: "the gate itself",
+    "validate-markdown": "read-only lint, publishes nothing",
+    "generate-snippets": "early-exits on main; writes only to staging",
+    "update-last-modified": "early-exits on main; writes only to staging",
+    "generate-related-articles": "early-exits on main; writes only to staging",
+    "check-deleted-files": "only removes Answers entries for files deleted in this commit; "
+                           "cannot publish held content",
+}
+
+
+def check_wiring(workflow_path):
+    try:
+        import yaml
+    except ImportError:
+        raise CheckerError("pyyaml is required for --check-wiring")
+    if not os.path.isfile(workflow_path):
+        raise CheckerError(f"workflow not found at {workflow_path}")
+    with open(workflow_path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    jobs = doc.get("jobs") or {}
+    if not jobs:
+        raise CheckerError(f"{workflow_path} declares no jobs")
+    if GATE_JOB not in jobs:
+        raise CheckerError(f"{workflow_path} has no {GATE_JOB!r} job")
+
+    def needs_of(name):
+        raw = (jobs.get(name) or {}).get("needs") or []
+        return [raw] if isinstance(raw, str) else list(raw)
+
+    def depends_on_gate(name):
+        """DIRECT dependency only, deliberately not transitive.
+
+        `sync` guards itself with `if: !failure() && !cancelled()`. Whether `failure()`
+        reaches a failure several edges up the needs graph is not something this repo has
+        measured, and run 27840821129 shows skip-propagation does NOT behave the way the
+        graph suggests: every job was skipped there and `sync` ran anyway. So a publishing
+        job must name the gate itself rather than inheriting it through a neighbour that
+        might merely be skipped.
+        """
+        return GATE_JOB in needs_of(name)
+
+    problems = []
+    for name in jobs:
+        if name in WIRING_EXEMPT:
+            continue
+        if not depends_on_gate(name):
+            problems.append(
+                f"job {name!r} does not depend on {GATE_JOB!r}, so a red gate would not "
+                f"stop it. Add {GATE_JOB!r} to its `needs`, or add it to WIRING_EXEMPT in "
+                f"{os.path.basename(__file__)} with the reason it cannot publish held content."
+            )
+    if needs_of(GATE_JOB):
+        problems.append(
+            f"{GATE_JOB!r} has `needs`, so another job failing would SKIP the gate. It must "
+            f"be a root job."
+        )
+
+    log(f"Workflow {workflow_path}: {len(jobs)} job(s).")
+    for name in sorted(jobs):
+        if name in WIRING_EXEMPT:
+            log(f"  - {name}: exempt ({WIRING_EXEMPT[name]})")
+        else:
+            log(f"  - {name}: gated ({'ok' if depends_on_gate(name) else 'NOT GATED'})")
+
+    if problems:
+        for problem in problems:
+            log(f"WIRING FAIL: {problem}")
+            annotate("error", f"promotion hold gate wiring: {problem}")
+        return 1
+    log("WIRING OK: every publishing job waits for the gate, and the gate is a root job.")
+    return 0
+
+
+# --------------------------------------------------------------------------------------
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--commit", default="HEAD")
+    parser.add_argument("--branch", default="")
+    parser.add_argument("--holds", default=".github/promotion-holds.txt")
+    parser.add_argument("--workflow", default=".github/workflows/documentation-pipeline.yml")
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--check-wiring", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.self_test:
+            log("Self-test: proving the gate can go RED and GREEN before trusting it.")
+            return self_test()
+        if args.check_wiring:
+            return check_wiring(os.path.join(args.repo, args.workflow))
+        if not args.branch:
+            raise CheckerError("--branch is required for the check")
+        holds_path = args.holds
+        if not os.path.isabs(holds_path):
+            holds_path = os.path.join(args.repo, holds_path)
+        return check(args.repo, args.commit, holds_path, args.branch)
+    except CheckerError as exc:
+        log(f"CHECKER ERROR: {exc}")
+        annotate("error", f"promotion hold check could not run: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## In plain English

**What this fixes.** Nine pages telling customers how to set up single sign-on went live on 2026-06-18 and stayed live for seven weeks while the screen they describe did not exist in production. There was supposed to be something holding them back. That something was a sentence in a GitHub issue, and a sentence in an issue cannot stop a merge.

**What it does.** Adds a check that fails a `staging` to `main` promotion when the promotion carries a path somebody has deliberately put on hold. The hold list is a file in the repo, so putting a path on hold is a reviewable diff with an author and a date instead of a promise someone has to remember.

**Why this way.** The alternative is to keep relying on a person remembering, which is what was tried and what failed silently for seven weeks with nobody at fault. The check is presence-based rather than diff-based on purpose: promotions here fast-forward, and the event that drives this pipeline carries no record of what `main` looked like before, so a diff-based check would have no baseline and would quietly pass whenever it could not work out an answer. Presence fails closed.

**How we got here.** `#88` asked for exactly this and then said so itself: *"only a path-based CI check on promotions to `main` would actually hold."* `#88` was closed on 2026-08-08 as overtaken by an owner decision to accept the published pages rather than unpublish them. That decision settled the nine pages. It did not build the control, and the control had no issue and no owner until `#118`.

## What changed

| File | What it is |
|---|---|
| `.github/promotion-holds.txt` | The hold list, as data. One line per hold: `<id>  <glob>  <reason>`. Ships with **no active holds** and a worked example kept commented out. |
| `scripts/promotion-hold-check.py` | The checker. Three modes: `--self-test`, `--check-wiring`, and the check itself. |
| `.github/workflows/documentation-pipeline.yml` | New `promotion-hold-gate` job, plus the `needs` edges that make it actually block. |
| `CLAUDE.md` | How to hold a path and how to release one, written where a promoter already looks. |

## The acceptance criterion that decides whether this is a gate or a decoration

A control promotion touching a held path must go **RED**, and the same promotion with the path removed must go **GREEN**. Both were run against the **real repository tree** at `origin/main`, with every assertion live including the "is this commit actually on main" ancestor check. Full output is pasted into #118.

```
### files in the real tree that this hold matches: 7
=================== RED: promotion carries the held path ===================
Verified 924841611 is on origin/main.
Promoted tree 924841611: 794 tracked path(s).
FAIL: this promotion carries paths that are on hold.
  hold   : sso-screens
  matched: 7 file(s)
RED exit code = 1   (expected 1)
================= GREEN: same promotion, held path removed =================
Verified 6d8ff8d78 is on origin/main.
Promoted tree 6d8ff8d78: 787 tracked path(s).
PASS: the promoted tree contains no held path.
GREEN exit code = 0   (expected 0)
```

794 paths minus the 7 held files is 787, so the two runs corroborate each other rather than each being read on its own.

The same red/green pair runs **inside the job on every promotion**, as its first step. That is the point: a check only ever observed passing is indistinguishable from one that cannot fail, and that is precisely the failure being fixed here. If the checker ever loses the ability to go red, the gate fails rather than waving the promotion through.

## Two things found while building it, both changed the design

**1. A gate carrying the usual `if:` would have been skipped on exactly the runs that publish unchecked.** Every other job in this pipeline is guarded by `if: github.event.workflow_run.conclusion == 'success'`. Copying that would have looked right. Measured on run **27840821129**: every job reads `skipped` and `sync` reads `success`. `sync` guards itself with `if: !failure() && !cancelled()`, a status-function conditional, which overrides the default "skip when a needed job was skipped". So when the triggering run does not succeed, everything skips and the publish still happens. A gate with that `if:` would be absent from the one case that matters most. This job therefore has **no `if:` and no `needs:`** and can never be skipped.

**2. The wiring is load-bearing, so it is asserted rather than trusted.** A red gate that does not block `sync` publishes anyway. The `--check-wiring` step reads the workflow file and requires every job that is not explicitly exempted to name the gate in its `needs`. It **discovers jobs from the file** rather than holding a frozen list, so adding a new publishing job forces a decision instead of silently escaping the gate. The dependency must be **direct, not transitive**: `sync` would otherwise inherit the gate through `upload-to-tallyfy-answers`, and whether `failure()` propagates several edges up the graph is not something this repo has measured. Run 27840821129 shows skip-propagation does not behave the way the graph suggests.

## What was verified, and what was not

Verified:

- Red and green controls against the real tree, both directions, output above.
- Self-test: 7 of 7 cases, covering red, green, deliberate release, release naming the wrong hold (releases nothing), the same held tree on `staging` (not blocked), a malformed hold line (fatal), and a missing hold list (fatal).
- Wiring guard proven able to fail: gate removed from `sync`'s needs → red; gate given a `needs:` → red; a new ungated job appended → red; gate deleted → error; **unmodified copy → green**, so it is not simply failing on everything.
- `python scripts/markdown-lint.py --dir=$PWD` and `python scripts/a11y-lint.py --dir=$PWD`, the exact commands `validate-markdown` runs: both exit 0.
- That `workflow_run.head_branch` really does read `main` on a real promotion, from the run logs of two real promotions, with staging-triggered runs as the negative control. The first version of that probe matched GitHub's echoed script listing as well as executed output and reported a false positive on both; the corrected probe returns 3 and 3 on the two main runs and 0 and 0 on the two staging runs.
- That `github.sha` is **not** the promoted commit on a `workflow_run` event. Run 30914229312 reported `sha=92156c924` for a push of `0c8011844` to main; run 30619407542 reported `c25ac48ea` for a push of `44fbbdbe5`. The gate uses `workflow_run.head_sha` and then re-verifies it is an ancestor of `origin/main`.

**Not verified:** the job has not run in GitHub Actions. It cannot, before merge. `workflow_run` workflows only run from the default branch, so this job does not exist on any real trigger path until this PR merges to `staging`, and the only way to observe it end to end is a promotion to `main`, which publishes to production. The layer this leaves unexercised is the workflow wiring itself, the `if`/`needs` edges and the `workflow_run` indirection. The checker, the hold list, the matcher, the release marker, the ancestor assertion and the wiring assertion are all exercised above.

**A known limit, stated rather than left to be discovered:** `generate-ids.yml` excludes `src/content/docs/pro/changelog/**` from its `paths:` filter, so a promotion touching only changelog paths starts no pipeline and no hold on a changelog path would ever be evaluated. It also publishes nothing, because `sync` would not run either. This is written into the hold list's own header so nobody puts a changelog path on hold and expects it to hold.

## Cost

The gate checks out with `fetch-depth: 0`, because `merge-base --is-ancestor` needs real history. `update-last-modified` in this same workflow already does the same, so this is a cost the pipeline already carries once.

---

## Also in this PR: two defects the gate work uncovered

Both were measured while building the gate, both are on the same main-promotion path, and the owner asked for both to be fixed now rather than queued.

### The pipeline handed git the wrong commit (#121)

On a `workflow_run` event `github.sha` is the head of the **default branch** (`staging`), not the commit that triggered the run.

| generate-ids run | pushed | pipeline run | `github.sha` the pipeline saw |
|---|---|---|---|
| 30914209849 | `0c8011844` to **main** | 30914229312 | `92156c924` |
| 30619394491 | `44fbbdbe5` to **main** | 30619407542 | `c25ac48ea` |

All five uses in this workflow now read `workflow_run.head_sha`. `generate-ids.yml` is deliberately untouched: it is `push`-triggered, where `github.sha` is correct, and changing it would introduce the bug rather than fix it.

`check-deleted-files` is the job this actually harms, since it prunes the **production** Answers index. It now also checks out the exact promoted commit rather than the branch tip, because it diffs that commit and a commit absent from a depth-2 checkout makes `git diff-tree` fail. Its two exit codes are now split apart: a `diff-tree` failure means we do not know what was deleted and must not proceed as though nothing was, while `grep` finding no `.mdx` legitimately means nothing was deleted. One `|| true` across the whole pipeline answered "nothing" to both.

### `sync` published even when every validation job was skipped (#122)

Run **27840821129**: `validate-markdown=skipped`, `generate-snippets=skipped`, `upload-to-tallyfy-answers=skipped`, `update-last-modified=skipped`, `check-deleted-files=skipped`, `generate-related-articles=skipped`, **`sync=success`**. `!failure() && !cancelled()` is a status-function conditional, which replaces the default "skip when a needed job was skipped", and neither term is true for a merely skipped need. So content could reach production without the markdown or accessibility lint having run.

Owner decision, taken deliberately rather than inherited: **block publishing**. `sync` now also requires `github.event.workflow_run.conclusion == 'success'`. The trade is that docs stop reaching production until a failed `generate-ids` run is fixed, which is the direction #118 is about.

That term cannot be observed locally, since it needs a genuinely failed upstream run and forcing one would publish a feature branch's content to `support-docs`. So `--check-wiring` asserts it statically, and that assertion is proven able to fail: removing the term from `sync`'s condition turns the check red, and the unmodified file stays green. The control fixture asserts its own search string matched before mutating, so a control that silently failed to apply aborts instead of reporting a pass.

## Control matrix for the wiring guard, all six run on the final file

| Mutation | Result | Want |
|---|---|---|
| `sync`'s upstream-success term removed | red | red |
| gate removed from `sync`'s `needs` | red | red |
| gate given a `needs:` | red | red |
| a new ungated publishing job appended | red | red |
| gate job deleted entirely | error | error |
| **unmodified copy** | **green** | **green** |

The last row is the one that makes the other five mean anything.

Fixes #118
Fixes #121
Fixes #122
