### PR TITLE
Make the Answers delete actually work, and fail loudly when it does not

### DIFF
--- a/scripts/check-deleted-files.py
+++ b/scripts/check-deleted-files.py
@@ -18,21 +18,43 @@ GITHUB_API_BASE = f'https://api.github.com/repos/{OWNER}/{REPO}/'
 # was removed in the commit (diff-filter=D), so running it on staging is safe.
 DEFAULT_ANSWERS_BASE_URL = 'https://answers.tallyfy.com'
 ANSWERS_API_KEY = None
+# Every delete that did not succeed. A non-empty list fails the run - see the note in
+# delete_object() for why this is not merely tidiness.
+FAILED_DELETES = []
+
+
 def delete_object(uid, tallyfy_answers_api):
 	"""
     Delete an object from the Tallyfy Answers API by its UID.
+
+    The header is the RAW key, not `Bearer <key>`. Measured against the production API on
+    2026-08-09 with a control, using a uid that does not exist so the probe changed nothing:
+    `Authorization: Bearer <key>` -> 403, `Authorization: <key>` -> 200, no header -> 403.
+    The no-header 403 is what makes the Bearer 403 mean "credential rejected" rather than
+    "endpoint ignores auth". This matches scripts/answers-connector.py, which had it right.
+    See tallyfy/documentation#124: this script sent Bearer, logged the 403, and exited 0, so
+    it had never deleted anything.
+
+    A failure is RECORDED and fails the run. Logging an error and carrying on is what hid the
+    bug above for as long as it existed: the job went green while doing nothing at all.
     """
 	headers = {
-		"Authorization": f"Bearer {ANSWERS_API_KEY}"
+		"Authorization": ANSWERS_API_KEY
 	}
 	try:
 		response = requests.delete(f'{tallyfy_answers_api}{uid}', headers=headers)
 		if response.status_code == 200:
 			logging.info(f"Successfully deleted object with UID: {uid}")
-		else:
-			logging.error(f"Failed to delete object with UID: {uid}. Status Code: {response.status_code}. Response: {response.json()}")
+			return
+		try:
+			body = response.json()
+		except Exception:
+			body = response.text[:300]
+		logging.error(f"Failed to delete object with UID: {uid}. Status Code: {response.status_code}. Response: {body}")
+		FAILED_DELETES.append((uid, f"HTTP {response.status_code}"))
 	except Exception as e:
 		logging.exception(f"An error occurred while deleting object with UID: {uid}: {e}")
+		FAILED_DELETES.append((uid, f"{type(e).__name__}: {e}"))
 
 def fetch_github_data(url, headers):
 	"""
@@ -126,6 +148,15 @@ def main():
 					logging.error(f"No content found in removed file: {file['filename']}")
 			except Exception as e:
 				logging.error(f"Error retrieving content for deleted file {file['filename']}: {e}")
+
+	# Fail the run if any delete did not land. An index entry for an article that no longer
+	# exists is a search result pointing at a page we removed, so "we tried" is not an
+	# acceptable outcome to pass over silently.
+	if FAILED_DELETES:
+		logging.error(f"{len(FAILED_DELETES)} delete(s) did not succeed:")
+		for uid, why in FAILED_DELETES:
+			logging.error(f"  {uid}: {why}")
+		sys.exit(1)
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
## In plain English

**What this fixes.** The script that removes deleted articles from the Tallyfy Answers search index has never removed anything. It sends the wrong kind of authorization header, the API refuses it, and the script writes the refusal to its log and carries on. The job has been reporting success while doing nothing.

**What it does.** Sends the header the API actually accepts, and makes a failed delete fail the job instead of being logged and passed over.

**Why this way.** The second half matters as much as the first. A delete that cannot happen must be loud, because being quiet is exactly what hid this. `scripts/answers-connector.py` in this same repo had the correct header all along, so the two scripts have disagreed with each other for as long as both have existed.

**How we got here.** Found while auditing the production index for #123, which was checking whether deleted articles had piled up in production search.

## The measurement

Against the production Answers API, using a uid that deliberately does not exist so the probe changed nothing:

| header sent to `DELETE /collections/tyfy/objects/{uid}` | result |
|---|---|
| `Authorization: Bearer <key>` - what this script sent | **403** |
| `Authorization: <key>` - what `answers-connector.py` sends | **200** |
| no `Authorization` header at all | 403 |

The third row is the control, and it is the row that makes the first mean something: because the endpoint 403s an anonymous request, the `Bearer` 403 is a **rejected credential**, not an endpoint that ignores auth and 403s everything.

## What this does NOT mean

**No stale entries accumulated.** #123 audited the production index the same day: **614 objects, 0 orphans** - every indexed entry has a live `.mdx` on `main`. The index stays consistent because `upload-to-tallyfy-answers` re-uploads the full document set on every run. So this job was inert rather than harmful, and the practical effect of the bug was that a safeguard we believed in was doing nothing.

## Controls, both directions

Run against a local stub HTTP server, so no production data moved:

| control | result |
|---|---|
| a delete that succeeds records 0 failures | ok |
| a delete refused with 403 records 1 failure | ok |
| an unreachable endpoint records 1 failure, not swallowed | ok |
| the header actually sent is the raw key | ok |
| the header does **not** start with `Bearer ` | ok |

The first row is the one that keeps the other four honest: without it, a guard that recorded a failure on every call would pass the same suite.

## What is not verified

**No delete has been observed succeeding against a real object**, because that would mean deleting a real production search entry to prove a point. The 200 above was against a non-existent uid, which proves the credential is accepted, not that a real removal completes end to end.

The remaining criterion on #123 covers exactly this: on the next ordinary content promotion that removes an article, confirm the entry leaves the production index. That is now a genuinely useful check, since before this change it could only ever have failed.

⚠️ **This makes deletion live for the first time.** Combined with #121, which corrected which commit the deletion list is computed from, this job goes from inert to real. That is the intent, and it was an explicit owner decision on 2026-08-09 rather than a quiet one-character change. If the file list is ever wrong, this job will now act on it - which is why the fail-loud half ships in the same PR.

Fixes #124
